### PR TITLE
feat(admin): build manage posts dashboard and edit capabilities

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,5 +38,7 @@ jobs:
 
       - name: Run semantic-release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
         run: npx semantic-release
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,10 @@ All notable changes to the NeoWhisper blog will be documented here.
 * Code quality: Removed if statements from remaining components (`ArticleCard.tsx` and `BlogPostTemplate.tsx`).
 * Admin dashboard: Refactored `AdminPage` for dynamic hydration from URL params and functional state initialization.
 * Bug fix: Resolved TypeScript/ESLint standalone expression errors in `posts-table.tsx` and `edit-form.tsx` using `void` ternary pattern.
+* Security: Updated CSP to whitelist Perplexity CDN (`r2cdn.perplexity.ai`) and additional Google AdSense domains, resolving font and script blocking errors.
+* Observability: Implemented a persistent, Supabase-backed logging system (`src/lib/logger.ts`) to capture production errors with stack traces.
+* Admin Dashboard: Added a new "Error Logs" management page (`/admin/logs`) to review system errors recorded in the database.
+* Refactoring: Satisfied React linting rules by decoupling data fetching from JSX construction in dynamic blog pages.
 * Observability: Added standardized client and server-side logging for all admin actions (create, update, delete, status change).
 
 ## [1.7.0] - 2026-02-09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,7 +81,10 @@ All notable changes to the NeoWhisper blog will be documented here.
 
 ## [Unreleased]
 
-* Code quality: Removed if statements from remaining components (`ArticleCard.tsx` and `BlogPostTemplate.tsx`)
+* Code quality: Removed if statements from remaining components (`ArticleCard.tsx` and `BlogPostTemplate.tsx`).
+* Admin dashboard: Refactored `AdminPage` for dynamic hydration from URL params and functional state initialization.
+* Bug fix: Resolved TypeScript/ESLint standalone expression errors in `posts-table.tsx` and `edit-form.tsx` using `void` ternary pattern.
+* Observability: Added standardized client and server-side logging for all admin actions (create, update, delete, status change).
 
 ## [1.7.0] - 2026-02-09
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # NeoWhisper - Modern Tech Blog
 
-> Current version: **v1.7.0**
+> Current version: **v1.9.0**
 
 A high-performance, SEO-optimized tech blog built with **Next.js 16**, **App Router**, and **MDX**.
 
@@ -96,17 +96,20 @@ author:
 This site uses a Content Security Policy to allow Google AdSense, Analytics, and Cloudflare Turnstile while maintaining security. The CSP is configured in `next.config.ts`.
 
 **Required domains for AdSense:**
+
 - `script-src`: Inline scripts for Next.js hydration, plus Google Tag Manager, Analytics, AdSense, and Turnstile
 - `connect-src`: API calls to Google Analytics, AdSense verification, and Turnstile
 - `frame-src`: iframes for AdSense ads, Turnstile challenges, and Google ad serving
 
 **If you see CSP errors in DevTools:**
+
 1. Open DevTools Console with ad blockers disabled
 2. Look for "Content Security Policy" errors
 3. Add only the blocked domain to the appropriate directive in `next.config.ts`
 4. Never use wildcard `*` - always specify exact domains
 
 **Current allowed domains:**
+
 - Google Analytics: `www.google-analytics.com`, `www.googletagmanager.com`
 - AdSense: `pagead2.googlesyndication.com`, `googleads.g.doubleclick.net`, `tpc.googlesyndication.com`, `*.google.com`, `adtrafficquality.google`, `*.adtrafficquality.google`, `fundingchoicesmessages.google.com`
 - Turnstile: `challenges.cloudflare.com`

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,7 +1,7 @@
 # NeoWhisper Engineering Roadmap (Internal)
 
-**Last Updated:** February 16, 2026  
-**Current Version:** v1.7.0  
+**Last Updated:** February 21, 2026  
+**Current Version:** v1.9.0  
 **Purpose:** Internal planning for engineering, infrastructure, AI-assisted workflows, and experiments.
 
 ---
@@ -10,7 +10,8 @@
 
 | Date | Version | What Was Completed |
 | --- | --- | --- |
-| 2026-02-16 | v1.7.0 | Business identity and service positioning update across core pages; security fix removing empty CORS headers from `robots.txt` and `sitemap.xml`. |
+| 2026-02-21 | v1.9.0 | Admin Dashboard refactor: dynamic hydration from URL parameters, functional state initialization, and fixed TypeScript expression errors. |
+| 2026-02-16 | v1.8.x-v1.8.2 | Business identity update; SEO and AdSense asset fixes; removed empty CORS headers from `robots.txt` and `sitemap.xml`. |
 | 2026-02-10 | v1.6.1 | Security hardening release: XSS fix and Next.js upgraded to `16.1.5`. |
 | 2026-02-09 | v1.6.0 | Contact pipeline maturity (Turnstile + Resend), AdSense/CSP readiness, and major multilingual marketing foundation work. |
 | 2026-02-02 | v1.5.1 | Playwright E2E testing introduced plus security headers and crawler endpoint hardening. |
@@ -30,16 +31,19 @@
 ## Active Sprint (0-30 days)
 
 ### Content Operations
+
 - [ ] Add MDX quality checks (frontmatter completeness, date format, language parity hints).
 - [ ] Define a stricter editorial QA checklist for EN/JA/AR consistency.
 - [ ] Normalize category naming and taxonomy mapping across all languages.
 
 ### Conversion and Trust
+
 - [ ] Expand client-facing case studies with measurable outcomes.
 - [ ] Tighten service package clarity (scope, deliverables, and expected timelines).
 - [ ] Improve public trust signals while keeping personal data exposure minimal.
 
 ### SEO and Discoverability
+
 - [ ] Evaluate migration plan for cleaner language routes (`/[lang]/...`).
 - [ ] Add internal linking standards per article type.
 - [ ] Review schema completeness for service and project pages.
@@ -49,17 +53,20 @@
 ## Near-Term (31-90 days)
 
 ### AI and Automation Track
+
 - [ ] Build internal AI-assisted translation QA workflow (terminology consistency and style checks).
 - [ ] Create AI-assisted metadata draft workflow with mandatory human approval.
 - [ ] Build a lightweight internal prompt library for article outlines, localization review, and release notes.
 
 ### Infrastructure and Reliability
+
 - [ ] Add structured error/event logging for contact submission flow.
 - [ ] Add rate-limit and anti-spam observability for contact endpoint.
 - [ ] Add synthetic health checks for critical public paths.
 - [ ] Define dependency and security update cadence with ownership.
 
 ### Developer Experience
+
 - [ ] Add scripts for repo health checks (content lint + link checks + metadata sanity).
 - [ ] Reduce repetitive copy/translations via shared dictionaries where practical.
 - [ ] Improve CI feedback ergonomics (clear failing summaries and remediation hints).

--- a/next.config.ts
+++ b/next.config.ts
@@ -21,12 +21,12 @@ const nextConfig: NextConfig = {
     const csp = [
       "default-src 'self'",
       `script-src 'self' 'unsafe-inline' ${process.env.NODE_ENV === "development" ? "'unsafe-eval'" : ""
-      } https://www.googletagmanager.com https://www.google-analytics.com https://pagead2.googlesyndication.com https://tpc.googlesyndication.com https://googleads.g.doubleclick.net https://www.googleadservices.com https://adtrafficquality.google https://*.adtrafficquality.google https://fundingchoicesmessages.google.com https://challenges.cloudflare.com https://partner.googleadservices.com`,
+      } https://www.googletagmanager.com https://www.google-analytics.com https://pagead2.googlesyndication.com https://tpc.googlesyndication.com https://googleads.g.doubleclick.net https://www.googleadservices.com https://adtrafficquality.google https://*.adtrafficquality.google https://fundingchoicesmessages.google.com https://challenges.cloudflare.com https://partner.googleadservices.com https://*.google.com`,
       "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
-      "img-src 'self' data: https:",
-      "font-src 'self' https://fonts.gstatic.com data:",
+      "img-src 'self' data: https: https://r2cdn.perplexity.ai",
+      "font-src 'self' https://fonts.gstatic.com data: https://r2cdn.perplexity.ai",
       `connect-src 'self' ${process.env.NODE_ENV === "development" ? "ws://127.0.0.1:* ws://localhost:*" : ""
-      } https://www.google-analytics.com https://www.googletagmanager.com https://pagead2.googlesyndication.com https://googleads.g.doubleclick.net https://www.googleadservices.com https://partner.googleadservices.com https://tpc.googlesyndication.com https://adtrafficquality.google https://*.adtrafficquality.google https://fundingchoicesmessages.google.com https://challenges.cloudflare.com https://*.google.com`,
+      } https://www.google-analytics.com https://www.googletagmanager.com https://pagead2.googlesyndication.com https://googleads.g.doubleclick.net https://www.googleadservices.com https://partner.googleadservices.com https://tpc.googlesyndication.com https://adtrafficquality.google https://*.adtrafficquality.google https://fundingchoicesmessages.google.com https://challenges.cloudflare.com https://*.google.com https://*.supabase.co`,
       "frame-src 'self' https://challenges.cloudflare.com https://googleads.g.doubleclick.net https://www.googleadservices.com https://partner.googleadservices.com https://tpc.googlesyndication.com https://*.google.com https://adtrafficquality.google https://*.adtrafficquality.google https://fundingchoicesmessages.google.com",
       "frame-ancestors 'none'",
       "base-uri 'self'",

--- a/src/app/admin/actions.ts
+++ b/src/app/admin/actions.ts
@@ -32,19 +32,16 @@ function normalizeSlug(value: string): string {
     .replace(/^-|-$/g, "");
 }
 
-function normalizeLocale(value: string): PostLocale {
-  if (value === "ja" || value === "ar") return value;
-  return "en";
-}
+const normalizeLocale = (value: string): PostLocale =>
+  (value === "ja" || value === "ar") ? value : "en";
 
-function hasRequiredContent(input: CreatePostInput): boolean {
-  return Boolean(
-    input.title.trim() &&
-    input.slug.trim() &&
-    input.content.trim() &&
+const hasRequiredContent = (input: CreatePostInput): boolean =>
+  Boolean(
+    input.title?.trim() &&
+    input.slug?.trim() &&
+    input.content?.trim() &&
     input.locale,
   );
-}
 
 export async function createPost(input: CreatePostInput): Promise<ActionResult> {
   if (!hasRequiredContent(input)) {
@@ -79,6 +76,7 @@ export async function createPost(input: CreatePostInput): Promise<ActionResult> 
     .maybeSingle();
 
   if (groupFetchError) {
+    console.error("[Admin:CreatePost] groupFetchError:", groupFetchError.message);
     return { error: `Failed to check translation group: ${groupFetchError.message}` };
   }
 
@@ -92,6 +90,7 @@ export async function createPost(input: CreatePostInput): Promise<ActionResult> 
       .single();
 
     if (createGroupError || !createdGroup) {
+      console.error("[Admin:CreatePost] createGroupError:", createGroupError?.message);
       return {
         error: `Failed to create translation group: ${createGroupError?.message ?? "unknown error"}`,
       };
@@ -116,6 +115,7 @@ export async function createPost(input: CreatePostInput): Promise<ActionResult> 
     .single();
 
   if (createPostError || !post) {
+    console.error("[Admin:CreatePost] createPostError:", createPostError?.message);
     return {
       error: `Failed to create post: ${createPostError?.message ?? "unknown error"}`,
     };
@@ -145,6 +145,7 @@ export async function updatePostStatus(postId: string, status: "draft" | "publis
     .eq("id", postId);
 
   if (error) {
+    console.error("[Admin:UpdateStatus] error:", error.message);
     return { error: `Failed to update status: ${error.message}` };
   }
 
@@ -167,6 +168,7 @@ export async function deletePost(postId: string): Promise<ActionResult> {
     .eq("id", postId);
 
   if (error) {
+    console.error("[Admin:DeletePost] error:", error.message);
     return { error: `Failed to delete post: ${error.message}` };
   }
 
@@ -222,6 +224,7 @@ export async function updatePostDetail(input: UpdatePostInput): Promise<ActionRe
     .eq("id", input.postId);
 
   if (error) {
+    console.error("[Admin:UpdateDetail] error:", error.message);
     return { error: `Failed to update post: ${error.message}` };
   }
 

--- a/src/app/admin/actions.ts
+++ b/src/app/admin/actions.ts
@@ -3,6 +3,7 @@
 import { revalidatePath } from "next/cache";
 import { isAllowedAdminEmail } from "@/lib/admin-auth";
 import { createSupabaseServerClient } from "@/lib/supabase-ssr";
+import { logger } from "@/lib/logger";
 
 type PostLocale = "en" | "ja" | "ar";
 
@@ -76,7 +77,7 @@ export async function createPost(input: CreatePostInput): Promise<ActionResult> 
     .maybeSingle();
 
   if (groupFetchError) {
-    console.error("[Admin:CreatePost] groupFetchError:", groupFetchError.message);
+    await logger.error("Admin:CreatePost", "groupFetchError", groupFetchError);
     return { error: `Failed to check translation group: ${groupFetchError.message}` };
   }
 
@@ -90,7 +91,7 @@ export async function createPost(input: CreatePostInput): Promise<ActionResult> 
       .single();
 
     if (createGroupError || !createdGroup) {
-      console.error("[Admin:CreatePost] createGroupError:", createGroupError?.message);
+      await logger.error("Admin:CreatePost", "createGroupError", createGroupError);
       return {
         error: `Failed to create translation group: ${createGroupError?.message ?? "unknown error"}`,
       };
@@ -115,7 +116,7 @@ export async function createPost(input: CreatePostInput): Promise<ActionResult> 
     .single();
 
   if (createPostError || !post) {
-    console.error("[Admin:CreatePost] createPostError:", createPostError?.message);
+    await logger.error("Admin:CreatePost", "createPostError", createPostError);
     return {
       error: `Failed to create post: ${createPostError?.message ?? "unknown error"}`,
     };
@@ -145,7 +146,7 @@ export async function updatePostStatus(postId: string, status: "draft" | "publis
     .eq("id", postId);
 
   if (error) {
-    console.error("[Admin:UpdateStatus] error:", error.message);
+    await logger.error("Admin:UpdateStatus", "error", error);
     return { error: `Failed to update status: ${error.message}` };
   }
 
@@ -168,7 +169,7 @@ export async function deletePost(postId: string): Promise<ActionResult> {
     .eq("id", postId);
 
   if (error) {
-    console.error("[Admin:DeletePost] error:", error.message);
+    await logger.error("Admin:DeletePost", "error", error);
     return { error: `Failed to delete post: ${error.message}` };
   }
 
@@ -224,7 +225,7 @@ export async function updatePostDetail(input: UpdatePostInput): Promise<ActionRe
     .eq("id", input.postId);
 
   if (error) {
-    console.error("[Admin:UpdateDetail] error:", error.message);
+    await logger.error("Admin:UpdateDetail", "error", error);
     return { error: `Failed to update post: ${error.message}` };
   }
 

--- a/src/app/admin/edit/[id]/edit-form.tsx
+++ b/src/app/admin/edit/[id]/edit-form.tsx
@@ -1,0 +1,266 @@
+"use client";
+
+import { useState } from "react";
+import { updatePostDetail } from "../../actions";
+import Link from "next/link";
+import { adminStrings } from "../../i18n";
+
+type LocaleValue = "en" | "ja" | "ar";
+
+const LOCALES: { value: LocaleValue; label: string; flag: string }[] = [
+    { value: "en", label: "English", flag: "🇬🇧" },
+    { value: "ja", label: "日本語", flag: "🇯🇵" },
+    { value: "ar", label: "العربية", flag: "🇸🇦" },
+];
+
+const inputClass =
+    "w-full rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-gray-100 placeholder-gray-500 outline-none ring-0 transition-all duration-200 focus:border-purple-500/60 focus:bg-white/8 focus:ring-2 focus:ring-purple-500/20 hover:border-white/20";
+
+const labelClass = "block text-xs font-semibold uppercase tracking-widest text-gray-400 mb-1.5";
+
+type EditFormProps = {
+    initialData: {
+        id: string;
+        title: string;
+        slug: string;
+        locale: LocaleValue;
+        category: string;
+        excerpt: string;
+        content: string;
+    };
+    tCommon: typeof adminStrings.en.page;
+    tEdit: typeof adminStrings.en.edit;
+};
+
+export default function EditForm({ initialData, tCommon, tEdit }: EditFormProps) {
+    const [form, setForm] = useState(initialData);
+    const [isLoading, setIsLoading] = useState(false);
+    const [status, setStatus] = useState<{ type: "success" | "error"; message: string } | null>(null);
+
+    function updateField<K extends keyof typeof initialData>(
+        key: K,
+        value: (typeof initialData)[K],
+    ) {
+        setForm((prev) => ({ ...prev, [key]: value }));
+    }
+
+    async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+        event.preventDefault();
+        setIsLoading(true);
+        setStatus(null);
+
+        const result = await updatePostDetail({
+            postId: form.id,
+            title: form.title,
+            slug: form.slug,
+            locale: form.locale,
+            category: form.category,
+            excerpt: form.excerpt,
+            content: form.content,
+        });
+
+        setIsLoading(false);
+
+        if (!result.success) {
+            setStatus({ type: "error", message: result.error ?? tEdit.failed });
+            return;
+        }
+
+        setStatus({ type: "success", message: result.message ?? tEdit.success });
+    }
+
+    const charCount = form.content.length;
+    const wordCount = form.content.trim() ? form.content.trim().split(/\s+/).length : 0;
+
+    return (
+        <>
+            {/* Page header */}
+            <div className="mx-auto max-w-3xl mb-8">
+                <Link href="/admin/posts" className="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-widest text-purple-400 hover:text-purple-300 transition-colors mb-4">
+                    {tEdit.backToPosts}
+                </Link>
+                <div className="flex items-center gap-3 mb-2">
+                    <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-purple-500/15 ring-1 ring-purple-500/30">
+                        <svg className="h-4 w-4 text-purple-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                            <path strokeLinecap="round" strokeLinejoin="round" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
+                        </svg>
+                    </div>
+                    <div>
+                        <p className="text-xs font-semibold uppercase tracking-widest text-purple-400">{tCommon.workspace}</p>
+                        <h1 className="text-2xl font-bold text-white leading-tight">{tEdit.title}</h1>
+                    </div>
+                </div>
+                <p className="text-sm text-gray-400 mt-1 ml-12">
+                    {tEdit.subtitle}
+                </p>
+            </div>
+
+            {/* Main card */}
+            <div className="mx-auto max-w-3xl">
+                <div className="overflow-hidden rounded-2xl border border-white/8 bg-white/[0.04] shadow-2xl shadow-black/40 backdrop-blur-xl">
+
+                    {/* Card top bar */}
+                    <div className="flex items-center gap-2 border-b border-white/8 px-6 py-4 bg-white/[0.02]">
+                        <span className="h-3 w-3 rounded-full bg-red-500/70" />
+                        <span className="h-3 w-3 rounded-full bg-yellow-500/70" />
+                        <span className="h-3 w-3 rounded-full bg-green-500/70" />
+                        <span className="ml-auto text-xs text-gray-500 font-mono">posts_dynamic • edit</span>
+                    </div>
+
+                    <form onSubmit={handleSubmit} className="p-6 space-y-5">
+
+                        {/* Title */}
+                        <div>
+                            <label htmlFor="admin-title" className={labelClass}>{tCommon.title} <span className="text-purple-400">*</span></label>
+                            <input
+                                id="admin-title"
+                                name="title"
+                                type="text"
+                                required
+                                value={form.title}
+                                onChange={(e) => updateField("title", e.target.value)}
+                                placeholder={tCommon.placeholderTitle}
+                                className={inputClass}
+                            />
+                        </div>
+
+                        {/* Slug */}
+                        <div>
+                            <label htmlFor="admin-slug" className={labelClass}>{tCommon.slug} <span className="text-purple-400">*</span></label>
+                            <p className="text-xs text-gray-500 mb-1.5">{tCommon.slugHint}</p>
+                            <div className="flex rounded-xl border border-white/10 bg-white/5 overflow-hidden focus-within:border-purple-500/60 focus-within:ring-2 focus-within:ring-purple-500/20">
+                                <span className="flex items-center border-r border-white/10 bg-white/[0.03] px-4 text-sm font-mono text-gray-500 shrink-0">/blog/</span>
+                                <input
+                                    id="admin-slug"
+                                    name="slug"
+                                    type="text"
+                                    required
+                                    value={form.slug}
+                                    onChange={(e) => updateField("slug", e.target.value.replace(/^\/+|\/+$/g, "").replace(/\/+/g, "-"))}
+                                    placeholder={tCommon.placeholderSlug}
+                                    className="flex-1 min-w-0 bg-transparent px-4 py-3 text-sm text-gray-100 placeholder-gray-500 outline-none font-mono"
+                                />
+                            </div>
+                        </div>
+
+                        {/* Locale + Category */}
+                        <div className="grid gap-4 sm:grid-cols-2">
+                            <div>
+                                <label htmlFor="admin-locale" className={labelClass}>{tCommon.language}</label>
+                                <div className="relative">
+                                    <span className="pointer-events-none absolute inset-y-0 left-4 flex items-center text-base leading-none">
+                                        {LOCALES.find((l) => l.value === form.locale)?.flag}
+                                    </span>
+                                    <select
+                                        id="admin-locale"
+                                        name="locale"
+                                        value={form.locale}
+                                        onChange={(e) => updateField("locale", e.target.value as LocaleValue)}
+                                        className={`${inputClass} pl-10 appearance-none cursor-pointer`}
+                                    >
+                                        {LOCALES.map((l) => (
+                                            <option key={l.value} value={l.value} className="bg-gray-900">
+                                                {l.label}
+                                            </option>
+                                        ))}
+                                    </select>
+                                </div>
+                            </div>
+
+                            <div>
+                                <label htmlFor="admin-category" className={labelClass}>{tCommon.category} <span className="text-gray-600">{tCommon.categoryOptional}</span></label>
+                                <input
+                                    id="admin-category"
+                                    name="category"
+                                    type="text"
+                                    value={form.category}
+                                    onChange={(e) => updateField("category", e.target.value)}
+                                    placeholder={tCommon.placeholderCategory}
+                                    className={inputClass}
+                                />
+                            </div>
+                        </div>
+
+                        {/* Excerpt */}
+                        <div>
+                            <label htmlFor="admin-excerpt" className={labelClass}>{tCommon.excerpt} <span className="text-gray-600">{tCommon.excerptOptional}</span></label>
+                            <textarea
+                                id="admin-excerpt"
+                                name="excerpt"
+                                value={form.excerpt}
+                                onChange={(e) => updateField("excerpt", e.target.value)}
+                                placeholder={tCommon.placeholderExcerpt}
+                                rows={2}
+                                className={`${inputClass} resize-none`}
+                            />
+                        </div>
+
+                        {/* Content */}
+                        <div>
+                            <div className="flex items-center justify-between mb-1.5">
+                                <label htmlFor="admin-content" className={`${labelClass} mb-0`}>
+                                    {tCommon.content} <span className="text-purple-400">*</span>
+                                </label>
+                                <span className="text-xs text-gray-500 font-mono tabular-nums">
+                                    {wordCount} {tCommon.wordLabel} · {charCount} {tCommon.charLabel}
+                                </span>
+                            </div>
+                            <textarea
+                                id="admin-content"
+                                name="content"
+                                required
+                                value={form.content}
+                                onChange={(e) => updateField("content", e.target.value)}
+                                placeholder={tCommon.placeholderContent}
+                                rows={16}
+                                className={`${inputClass} font-mono resize-y leading-relaxed`}
+                            />
+                        </div>
+
+                        {/* Status banner */}
+                        {status && (
+                            <div
+                                role="alert"
+                                className={`flex items-start gap-3 rounded-xl px-4 py-3 text-sm ${status.type === "success"
+                                    ? "bg-emerald-500/10 border border-emerald-500/25 text-emerald-300"
+                                    : "bg-red-500/10 border border-red-500/25 text-red-300"
+                                    }`}
+                            >
+                                <span className="mt-0.5 shrink-0 text-base leading-none">
+                                    {status.type === "success" ? "✓" : "✕"}
+                                </span>
+                                {status.message}
+                            </div>
+                        )}
+
+                        {/* Submit */}
+                        <div className="flex items-center justify-end pt-1">
+                            <button
+                                type="submit"
+                                disabled={isLoading}
+                                className="inline-flex items-center gap-2 rounded-xl bg-purple-600 px-6 py-2.5 text-sm font-semibold text-white shadow-lg shadow-purple-500/20 transition-all hover:bg-purple-500 hover:shadow-purple-500/30 disabled:opacity-50 disabled:cursor-not-allowed"
+                            >
+                                {isLoading ? (
+                                    <>
+                                        <svg className="h-4 w-4 animate-spin" fill="none" viewBox="0 0 24 24">
+                                            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                                            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                                        </svg>
+                                        {tEdit.saving}
+                                    </>
+                                ) : (
+                                    <>
+                                        <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+                                            <path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0z" />
+                                        </svg>
+                                        {tEdit.saveChanges}
+                                    </>
+                                )}
+                            </button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </>
+    );
+}

--- a/src/app/admin/edit/[id]/edit-form.tsx
+++ b/src/app/admin/edit/[id]/edit-form.tsx
@@ -37,14 +37,12 @@ export default function EditForm({ initialData, tCommon, tEdit }: EditFormProps)
     const [isLoading, setIsLoading] = useState(false);
     const [status, setStatus] = useState<{ type: "success" | "error"; message: string } | null>(null);
 
-    function updateField<K extends keyof typeof initialData>(
+    const updateField = <K extends keyof typeof initialData>(
         key: K,
         value: (typeof initialData)[K],
-    ) {
-        setForm((prev) => ({ ...prev, [key]: value }));
-    }
+    ) => setForm((prev) => ({ ...prev, [key]: value }));
 
-    async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
         event.preventDefault();
         setIsLoading(true);
         setStatus(null);
@@ -61,13 +59,10 @@ export default function EditForm({ initialData, tCommon, tEdit }: EditFormProps)
 
         setIsLoading(false);
 
-        if (!result.success) {
-            setStatus({ type: "error", message: result.error ?? tEdit.failed });
-            return;
-        }
-
-        setStatus({ type: "success", message: result.message ?? tEdit.success });
-    }
+        void (!result.success
+            ? (console.error("[EditForm:Submit] error:", result.error), setStatus({ type: "error", message: result.error ?? tEdit.failed }))
+            : setStatus({ type: "success", message: result.message ?? tEdit.success }));
+    };
 
     const charCount = form.content.length;
     const wordCount = form.content.trim() ? form.content.trim().split(/\s+/).length : 0;

--- a/src/app/admin/edit/[id]/page.tsx
+++ b/src/app/admin/edit/[id]/page.tsx
@@ -1,0 +1,57 @@
+import { createSupabaseServerClient } from "@/lib/supabase-ssr";
+import { isAllowedAdminEmail } from "@/lib/admin-auth";
+import { notFound, redirect } from "next/navigation";
+import { adminStrings, normalizeAdminLang } from "../../i18n";
+import EditForm from "./edit-form";
+
+export const dynamic = "force-dynamic";
+
+export default async function EditPostPage({
+    params,
+    searchParams,
+}: {
+    params: Promise<{ id: string }>;
+    searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+}) {
+    const supabase = await createSupabaseServerClient();
+    const { data: { user } } = await supabase.auth.getUser();
+
+    if (!user || !isAllowedAdminEmail(user.email)) {
+        redirect("/");
+    }
+
+    const { id } = await params;
+    const resolvedParams = await searchParams;
+    const lang = normalizeAdminLang(typeof resolvedParams.lang === "string" ? resolvedParams.lang : undefined);
+
+    const tCommon = adminStrings[lang].page;
+    const tEdit = adminStrings[lang].edit;
+
+    const { data: post, error } = await supabase
+        .from("posts_dynamic")
+        .select("*, slug:translation_groups(slug)")
+        .eq("id", id)
+        .single();
+
+    if (error || !post) {
+        notFound();
+    }
+
+    const slugObj = Array.isArray(post.slug) ? post.slug[0] : post.slug;
+
+    const initialData = {
+        id: post.id,
+        title: post.title,
+        slug: slugObj?.slug || "",
+        locale: post.locale as "en" | "ja" | "ar",
+        category: post.category || "",
+        excerpt: post.excerpt || "",
+        content: post.content || "",
+    };
+
+    return (
+        <main className="min-h-screen px-4 py-12 sm:px-6 lg:px-8">
+            <EditForm initialData={initialData} tCommon={tCommon} tEdit={tEdit} />
+        </main>
+    );
+}

--- a/src/app/admin/i18n.ts
+++ b/src/app/admin/i18n.ts
@@ -6,6 +6,8 @@ export const adminStrings: Record<
     layout: {
       backToSite: string;
       internalOnly: string;
+      newPost: string;
+      managePosts: string;
     };
     page: {
       workspace: string;
@@ -34,12 +36,28 @@ export const adminStrings: Record<
       wordLabel: string;
       charLabel: string;
     };
+    posts: {
+      title: string;
+      subtitle: string;
+      status: string;
+      locale: string;
+      actions: string;
+      draft: string;
+      published: string;
+      publish: string;
+      unpublish: string;
+      delete: string;
+      confirmDelete: string;
+      emptyState: string;
+    };
   }
 > = {
   en: {
     layout: {
       backToSite: "← Back to site",
       internalOnly: "NeoWhisper Admin · Internal use only",
+      newPost: "New Post",
+      managePosts: "Manage Posts",
     },
     page: {
       workspace: "Admin Workspace",
@@ -68,11 +86,27 @@ export const adminStrings: Record<
       wordLabel: "words",
       charLabel: "chars",
     },
+    posts: {
+      title: "Manage Posts",
+      subtitle: "Review, publish, unpublish, and delete blog posts.",
+      status: "Status",
+      locale: "Locale",
+      actions: "Actions",
+      draft: "Draft",
+      published: "Published",
+      publish: "Publish",
+      unpublish: "Unpublish",
+      delete: "Delete",
+      confirmDelete: "Are you sure you want to delete this post?",
+      emptyState: "No posts found.",
+    },
   },
   ja: {
     layout: {
       backToSite: "← サイトに戻る",
       internalOnly: "NeoWhisper 管理 · 社内利用のみ",
+      newPost: "新規投稿",
+      managePosts: "投稿管理",
     },
     page: {
       workspace: "管理ワークスペース",
@@ -100,6 +134,20 @@ export const adminStrings: Record<
       placeholderContent: "# タイトル\n\nMarkdown で本文を入力…",
       wordLabel: "単語",
       charLabel: "文字",
+    },
+    posts: {
+      title: "投稿管理",
+      subtitle: "ブログ投稿のレビュー、公開、非公開、削除を行います。",
+      status: "ステータス",
+      locale: "言語",
+      actions: "アクション",
+      draft: "下書き",
+      published: "公開済",
+      publish: "公開する",
+      unpublish: "非公開にする",
+      delete: "削除",
+      confirmDelete: "本当にこの投稿を削除しますか？",
+      emptyState: "投稿が見つかりません。",
     },
   },
 };

--- a/src/app/admin/i18n.ts
+++ b/src/app/admin/i18n.ts
@@ -47,8 +47,19 @@ export const adminStrings: Record<
       publish: string;
       unpublish: string;
       delete: string;
+      edit: string;
       confirmDelete: string;
       emptyState: string;
+    };
+    edit: {
+      title: string;
+      subtitle: string;
+      saveChanges: string;
+      saving: string;
+      success: string;
+      failed: string;
+      backToPosts: string;
+      notFound: string;
     };
   }
 > = {
@@ -97,8 +108,19 @@ export const adminStrings: Record<
       publish: "Publish",
       unpublish: "Unpublish",
       delete: "Delete",
+      edit: "Edit",
       confirmDelete: "Are you sure you want to delete this post?",
       emptyState: "No posts found.",
+    },
+    edit: {
+      title: "Edit Post",
+      subtitle: "Update the content and settings for your existing post.",
+      saveChanges: "Save Changes",
+      saving: "Saving…",
+      success: "Post updated successfully.",
+      failed: "Failed to update post.",
+      backToPosts: "← Back to Posts",
+      notFound: "Post not found.",
     },
   },
   ja: {
@@ -146,8 +168,19 @@ export const adminStrings: Record<
       publish: "公開する",
       unpublish: "非公開にする",
       delete: "削除",
+      edit: "編集",
       confirmDelete: "本当にこの投稿を削除しますか？",
       emptyState: "投稿が見つかりません。",
+    },
+    edit: {
+      title: "投稿を編集",
+      subtitle: "既存の投稿のコンテンツと設定を更新します。",
+      saveChanges: "変更を保存",
+      saving: "保存中…",
+      success: "投稿を更新しました。",
+      failed: "投稿の更新に失敗しました。",
+      backToPosts: "← 投稿一覧に戻る",
+      notFound: "投稿が見つかりません。",
     },
   },
 };

--- a/src/app/admin/i18n.ts
+++ b/src/app/admin/i18n.ts
@@ -48,6 +48,8 @@ export const adminStrings: Record<
       unpublish: string;
       delete: string;
       edit: string;
+      translations: string;
+      addTranslation: string;
       confirmDelete: string;
       emptyState: string;
     };
@@ -109,6 +111,8 @@ export const adminStrings: Record<
       unpublish: "Unpublish",
       delete: "Delete",
       edit: "Edit",
+      translations: "Translations",
+      addTranslation: "Add Translation",
       confirmDelete: "Are you sure you want to delete this post?",
       emptyState: "No posts found.",
     },
@@ -169,6 +173,8 @@ export const adminStrings: Record<
       unpublish: "非公開にする",
       delete: "削除",
       edit: "編集",
+      translations: "他言語",
+      addTranslation: "翻訳を追加",
       confirmDelete: "本当にこの投稿を削除しますか？",
       emptyState: "投稿が見つかりません。",
     },

--- a/src/app/admin/i18n.ts
+++ b/src/app/admin/i18n.ts
@@ -8,6 +8,7 @@ export const adminStrings: Record<
       internalOnly: string;
       newPost: string;
       managePosts: string;
+      logs: string;
     };
     page: {
       workspace: string;
@@ -63,6 +64,15 @@ export const adminStrings: Record<
       backToPosts: string;
       notFound: string;
     };
+    logs: {
+      title: string;
+      subtitle: string;
+      level: string;
+      module: string;
+      message: string;
+      time: string;
+      noLogs: string;
+    };
   }
 > = {
   en: {
@@ -71,6 +81,7 @@ export const adminStrings: Record<
       internalOnly: "NeoWhisper Admin · Internal use only",
       newPost: "New Post",
       managePosts: "Manage Posts",
+      logs: "Error Logs",
     },
     page: {
       workspace: "Admin Workspace",
@@ -126,6 +137,15 @@ export const adminStrings: Record<
       backToPosts: "← Back to Posts",
       notFound: "Post not found.",
     },
+    logs: {
+      title: "Error Logs",
+      subtitle: "Review system errors captured from production and local environments.",
+      level: "Level",
+      module: "Module",
+      message: "Message",
+      time: "Time",
+      noLogs: "No error logs found.",
+    },
   },
   ja: {
     layout: {
@@ -133,6 +153,7 @@ export const adminStrings: Record<
       internalOnly: "NeoWhisper 管理 · 社内利用のみ",
       newPost: "新規投稿",
       managePosts: "投稿管理",
+      logs: "エラーログ",
     },
     page: {
       workspace: "管理ワークスペース",
@@ -187,6 +208,15 @@ export const adminStrings: Record<
       failed: "投稿の更新に失敗しました。",
       backToPosts: "← 投稿一覧に戻る",
       notFound: "投稿が見つかりません。",
+    },
+    logs: {
+      title: "Error Logs",
+      subtitle: "Review system errors captured from production and local environments.",
+      level: "Level",
+      module: "Module",
+      message: "Message",
+      time: "Time",
+      noLogs: "No error logs found.",
     },
   },
 };

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -75,6 +75,12 @@ function AdminLayoutInner({ children }: { children: React.ReactNode }) {
           >
             {t.managePosts}
           </Link>
+          <Link
+            href={`/admin/logs${lang === "ja" ? "?lang=ja" : ""}`}
+            className={`border-b-2 px-1 py-4 text-sm font-medium transition-colors ${pathname === "/admin/logs" ? "border-purple-400 text-purple-400" : "border-transparent text-gray-400 hover:border-gray-500 hover:text-gray-200"}`}
+          >
+            {t.logs}
+          </Link>
         </div>
       </div>
 

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,16 +1,16 @@
 "use client";
 
 import Link from "next/link";
-import { useSearchParams } from "next/navigation";
+import { useSearchParams, usePathname } from "next/navigation";
 import { Suspense } from "react";
 import { adminStrings, normalizeAdminLang } from "./i18n";
 
 function AdminLayoutInner({ children }: { children: React.ReactNode }) {
   const searchParams = useSearchParams();
+  const pathname = usePathname();
   const lang = normalizeAdminLang(searchParams.get("lang"));
 
   const t = adminStrings[lang].layout;
-  const base = "/admin";
 
   return (
     <div
@@ -38,13 +38,13 @@ function AdminLayoutInner({ children }: { children: React.ReactNode }) {
             </span>
             <span className="text-gray-600">|</span>
             <Link
-              href={lang === "ja" ? base : `${base}?lang=ja`}
+              href={lang === "ja" ? pathname : `${pathname}?lang=ja`}
               className={`text-xs ${lang === "ja" ? "text-purple-400 font-medium" : "text-gray-500 hover:text-gray-300"}`}
             >
               日本語
             </Link>
             <Link
-              href={lang === "en" ? base : `${base}?lang=en`}
+              href={lang === "en" ? pathname : `${pathname}?lang=en`}
               className={`text-xs ${lang === "en" ? "text-purple-400 font-medium" : "text-gray-500 hover:text-gray-300"}`}
             >
               EN
@@ -59,6 +59,24 @@ function AdminLayoutInner({ children }: { children: React.ReactNode }) {
           </Link>
         </div>
       </header>
+
+      {/* Admin Nav Tabs */}
+      <div className="border-b border-white/8 bg-black/10">
+        <div className="mx-auto flex max-w-3xl items-center gap-6 px-4 sm:px-6 lg:px-8">
+          <Link
+            href={`/admin${lang === "ja" ? "?lang=ja" : ""}`}
+            className={`border-b-2 px-1 py-4 text-sm font-medium transition-colors ${pathname === "/admin" ? "border-purple-400 text-purple-400" : "border-transparent text-gray-400 hover:border-gray-500 hover:text-gray-200"}`}
+          >
+            {t.newPost}
+          </Link>
+          <Link
+            href={`/admin/posts${lang === "ja" ? "?lang=ja" : ""}`}
+            className={`border-b-2 px-1 py-4 text-sm font-medium transition-colors ${pathname === "/admin/posts" ? "border-purple-400 text-purple-400" : "border-transparent text-gray-400 hover:border-gray-500 hover:text-gray-200"}`}
+          >
+            {t.managePosts}
+          </Link>
+        </div>
+      </div>
 
       <div className="flex-1">{children}</div>
 

--- a/src/app/admin/logs/page.tsx
+++ b/src/app/admin/logs/page.tsx
@@ -1,0 +1,124 @@
+
+import { createSupabaseServerClient } from "@/lib/supabase-ssr";
+import { isAllowedAdminEmail } from "@/lib/admin-auth";
+import { redirect } from "next/navigation";
+import { adminStrings, normalizeAdminLang } from "../i18n";
+
+export const dynamic = "force-dynamic";
+
+export default async function AdminLogsPage({
+    searchParams,
+}: {
+    searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+}) {
+    const supabase = await createSupabaseServerClient();
+    const { data: { user } } = await supabase.auth.getUser();
+
+    if (!user || !isAllowedAdminEmail(user.email)) {
+        redirect("/");
+    }
+
+    const resolvedParams = await searchParams;
+    const lang = normalizeAdminLang(typeof resolvedParams.lang === "string" ? resolvedParams.lang : undefined);
+    const t = adminStrings[lang].logs;
+
+    // Fetch logs ordered by created_at desc
+    const { data: logs, error } = await supabase
+        .from("error_logs")
+        .select("*")
+        .order("created_at", { ascending: false })
+        .limit(100);
+
+    if (error) {
+        console.error("Failed to fetch logs:", error);
+    }
+
+    return (
+        <main className="min-h-screen px-4 py-12 sm:px-6 lg:px-8 bg-gray-950 text-white">
+            {/* Page header */}
+            <div className="mx-auto max-w-6xl mb-8">
+                <div className="flex items-center gap-3 mb-2">
+                    <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-red-500/15 ring-1 ring-red-500/30">
+                        <svg className="h-4 w-4 text-red-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                            <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+                        </svg>
+                    </div>
+                    <div>
+                        <h1 className="text-2xl font-bold text-white leading-tight">{t.title}</h1>
+                    </div>
+                </div>
+                <p className="text-sm text-gray-400 mt-1 ml-12">
+                    {t.subtitle}
+                </p>
+            </div>
+
+            <div className="mx-auto max-w-6xl">
+                <div className="overflow-hidden rounded-2xl border border-white/8 bg-white/[0.04] shadow-2xl shadow-black/40 backdrop-blur-xl">
+                    <div className="overflow-x-auto">
+                        <table className="w-full text-left text-sm border-collapse">
+                            <thead>
+                                <tr className="border-b border-white/10 bg-white/[0.02]">
+                                    <th className="px-6 py-4 font-semibold text-gray-300 w-24">{t.level}</th>
+                                    <th className="px-6 py-4 font-semibold text-gray-300 w-32">{t.module}</th>
+                                    <th className="px-6 py-4 font-semibold text-gray-300">{t.message}</th>
+                                    <th className="px-6 py-4 font-semibold text-gray-300 w-48">{t.time}</th>
+                                </tr>
+                            </thead>
+                            <tbody className="divide-y divide-white/5">
+                                {logs && logs.length > 0 ? (
+                                    logs.map((log) => (
+                                        <tr key={log.id} className="hover:bg-white/[0.02] transition-colors group">
+                                            <td className="px-6 py-4">
+                                                <span className={`px-2 py-1 rounded-md text-[10px] uppercase font-bold tracking-wider ${log.level === 'error' ? 'bg-red-500/20 text-red-400 border border-red-500/30' :
+                                                        log.level === 'warn' ? 'bg-amber-500/20 text-amber-400 border border-amber-500/30' :
+                                                            'bg-blue-500/20 text-blue-400 border border-blue-500/30'
+                                                    }`}>
+                                                    {log.level}
+                                                </span>
+                                            </td>
+                                            <td className="px-6 py-4 font-mono text-xs text-purple-400">
+                                                {log.module}
+                                            </td>
+                                            <td className="px-6 py-4">
+                                                <div className="flex flex-col gap-1">
+                                                    <span className="text-gray-100 font-medium">{log.message}</span>
+                                                    {log.stack && (
+                                                        <details className="mt-2 group/stack">
+                                                            <summary className="text-[10px] text-gray-500 cursor-pointer hover:text-gray-300 list-none flex items-center gap-1">
+                                                                <svg className="w-3 h-3 group-open/stack:rotate-90 transition-transform" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={3} d="M9 5l7 7-7 7" />
+                                                                </svg>
+                                                                View Stack Trace
+                                                            </summary>
+                                                            <pre className="mt-2 p-3 bg-black/40 rounded-lg text-[10px] font-mono text-gray-400 overflow-x-auto whitespace-pre-wrap max-h-64 border border-white/5">
+                                                                {log.stack}
+                                                            </pre>
+                                                        </details>
+                                                    )}
+                                                    {log.context && (
+                                                        <div className="mt-1 text-[10px] text-gray-500 font-mono">
+                                                            Context: {JSON.stringify(log.context)}
+                                                        </div>
+                                                    )}
+                                                </div>
+                                            </td>
+                                            <td className="px-6 py-4 text-xs text-gray-500 font-mono">
+                                                {new Date(log.created_at).toLocaleString(lang === 'ja' ? 'ja-JP' : 'en-US')}
+                                            </td>
+                                        </tr>
+                                    ))
+                                ) : (
+                                    <tr>
+                                        <td colSpan={4} className="px-6 py-12 text-center text-gray-500 italic">
+                                            {t.noLogs}
+                                        </td>
+                                    </tr>
+                                )}
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </main>
+    );
+}

--- a/src/app/admin/posts/page.tsx
+++ b/src/app/admin/posts/page.tsx
@@ -25,7 +25,7 @@ export default async function AdminPostsPage({
     // Fetch all posts order by created_at desc
     const { data: posts, error } = await supabase
         .from("posts_dynamic")
-        .select("id, title, status, locale, created_at, slug:translation_groups(slug)")
+        .select("id, title, status, locale, created_at, category, slug:translation_groups(slug)")
         .order("created_at", { ascending: false });
 
     if (error) {
@@ -38,6 +38,7 @@ export default async function AdminPostsPage({
         status: "draft" | "published";
         locale: string;
         created_at: string;
+        category: string | null;
         slug: { slug: string } | { slug: string }[] | null;
     };
 
@@ -48,6 +49,7 @@ export default async function AdminPostsPage({
             title: p.title,
             status: p.status,
             locale: p.locale,
+            category: p.category || "",
             slug: slugObj?.slug || "unknown",
             createdAt: new Date(p.created_at).toLocaleDateString(lang === "ja" ? "ja-JP" : "en-US", {
                 year: "numeric",

--- a/src/app/admin/posts/page.tsx
+++ b/src/app/admin/posts/page.tsx
@@ -1,0 +1,86 @@
+import { createSupabaseServerClient } from "@/lib/supabase-ssr";
+import { isAllowedAdminEmail } from "@/lib/admin-auth";
+import { redirect } from "next/navigation";
+import { adminStrings, normalizeAdminLang } from "../i18n";
+import PostsTable from "./posts-table";
+
+export const dynamic = "force-dynamic";
+
+export default async function AdminPostsPage({
+    searchParams,
+}: {
+    searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+}) {
+    const supabase = await createSupabaseServerClient();
+    const { data: { user } } = await supabase.auth.getUser();
+
+    if (!user || !isAllowedAdminEmail(user.email)) {
+        redirect("/");
+    }
+
+    const resolvedParams = await searchParams;
+    const lang = normalizeAdminLang(typeof resolvedParams.lang === "string" ? resolvedParams.lang : undefined);
+    const t = adminStrings[lang].posts;
+
+    // Fetch all posts order by created_at desc
+    const { data: posts, error } = await supabase
+        .from("posts_dynamic")
+        .select("id, title, status, locale, created_at, slug:translation_groups(slug)")
+        .order("created_at", { ascending: false });
+
+    if (error) {
+        console.error("Failed to fetch posts:", error);
+    }
+
+    type PostRow = {
+        id: string;
+        title: string;
+        status: "draft" | "published";
+        locale: string;
+        created_at: string;
+        slug: { slug: string } | { slug: string }[] | null;
+    };
+
+    const formattedPosts = ((posts as unknown as PostRow[]) || []).map((p) => {
+        const slugObj = Array.isArray(p.slug) ? p.slug[0] : p.slug;
+        return {
+            id: p.id,
+            title: p.title,
+            status: p.status,
+            locale: p.locale,
+            slug: slugObj?.slug || "unknown",
+            createdAt: new Date(p.created_at).toLocaleDateString(lang === "ja" ? "ja-JP" : "en-US", {
+                year: "numeric",
+                month: "short",
+                day: "numeric",
+            }),
+        };
+    });
+
+    return (
+        <main className="min-h-screen px-4 py-12 sm:px-6 lg:px-8">
+            {/* Page header */}
+            <div className="mx-auto max-w-5xl mb-8">
+                <div className="flex items-center gap-3 mb-2">
+                    <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-purple-500/15 ring-1 ring-purple-500/30">
+                        <svg className="h-4 w-4 text-purple-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                            <path strokeLinecap="round" strokeLinejoin="round" d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 002-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" />
+                        </svg>
+                    </div>
+                    <div>
+                        <h1 className="text-2xl font-bold text-white leading-tight">{t.title}</h1>
+                    </div>
+                </div>
+                <p className="text-sm text-gray-400 mt-1 ml-12">
+                    {t.subtitle}
+                </p>
+            </div>
+
+            <div className="mx-auto max-w-5xl">
+                <div className="overflow-hidden rounded-2xl border border-white/8 bg-white/[0.04] shadow-2xl shadow-black/40 backdrop-blur-xl">
+                    <PostsTable posts={formattedPosts} dict={t} />
+                </div>
+            </div>
+        </main>
+    );
+}

--- a/src/app/admin/posts/posts-table.tsx
+++ b/src/app/admin/posts/posts-table.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import Link from "next/link";
 import { deletePost, updatePostStatus } from "../actions";
 
 import { adminStrings } from "../i18n";
@@ -101,6 +102,13 @@ export default function PostsTable({ posts, dict }: PostsTableProps) {
                                             {dict.unpublish}
                                         </button>
                                     )}
+                                    <span className="text-white/10">|</span>
+                                    <Link
+                                        href={`/admin/edit/${post.id}`}
+                                        className="text-blue-400 hover:text-blue-300 transition-colors"
+                                    >
+                                        {dict.edit}
+                                    </Link>
                                     <span className="text-white/10">|</span>
                                     <button
                                         disabled={isProcessing === post.id}

--- a/src/app/admin/posts/posts-table.tsx
+++ b/src/app/admin/posts/posts-table.tsx
@@ -12,6 +12,7 @@ type Post = {
     status: "draft" | "published";
     locale: string;
     slug: string;
+    category: string;
     createdAt: string;
 };
 
@@ -26,101 +27,130 @@ export default function PostsTable({ posts, dict }: PostsTableProps) {
     const handleStatusChange = async (post: Post, newStatus: "draft" | "published") => {
         setIsProcessing(post.id);
         const result = await updatePostStatus(post.id, newStatus);
-        if (result.error) alert(result.error);
+        void (result.error ? (console.error("[PostsTable:StatusChange] error:", result.error), alert(result.error)) : null);
         setIsProcessing(null);
     };
 
     const handleDelete = async (postId: string) => {
-        if (!confirm(dict.confirmDelete)) return;
-        setIsProcessing(postId);
-        const result = await deletePost(postId);
-        if (result.error) alert(result.error);
+        const result = confirm(dict.confirmDelete) && (setIsProcessing(postId), await deletePost(postId));
+        void (result && result.error ? (console.error("[PostsTable:Delete] error:", result.error), alert(result.error)) : null);
         setIsProcessing(null);
     };
 
-    if (posts.length === 0) {
-        return (
-            <div className="p-12 text-center text-sm text-gray-400">
-                {dict.emptyState}
-            </div>
-        );
-    }
+    const ALL_LOCALES: { value: string; flag: string }[] = [
+        { value: "en", flag: "🇬🇧" },
+        { value: "ja", flag: "🇯🇵" },
+        { value: "ar", flag: "🇸🇦" },
+    ];
 
-    return (
+    return posts.length === 0 ? (
+        <div className="p-12 text-center text-sm text-gray-400">
+            {dict.emptyState}
+        </div>
+    ) : (
         <div className="overflow-x-auto">
             <table className="w-full text-left text-sm text-gray-300">
                 <thead className="bg-white/5 text-xs font-semibold uppercase tracking-widest text-gray-400 border-b border-white/5">
                     <tr>
                         <th className="px-6 py-4">{dict.title}</th>
                         <th className="px-6 py-4">{dict.locale}</th>
+                        <th className="px-6 py-4">{dict.translations}</th>
                         <th className="px-6 py-4">{dict.status}</th>
                         <th className="px-6 py-4">Date</th>
                         <th className="px-6 py-4 text-right">{dict.actions}</th>
                     </tr>
                 </thead>
                 <tbody className="divide-y divide-white/5">
-                    {posts.map((post) => (
-                        <tr key={post.id} className="transition-colors hover:bg-white/[0.02]">
-                            <td className="px-6 py-4">
-                                <div className="font-medium text-gray-100">{post.title}</div>
-                                <div className="text-xs text-gray-500 font-mono mt-0.5">/blog/{post.slug}</div>
-                            </td>
-                            <td className="px-6 py-4">
-                                <span className="inline-flex items-center rounded-md bg-white/10 px-2 py-1 text-xs font-medium text-gray-300 ring-1 ring-inset ring-white/10">
-                                    {post.locale.toUpperCase()}
-                                </span>
-                            </td>
-                            <td className="px-6 py-4">
-                                <span
-                                    className={`inline-flex items-center rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset ${post.status === "published"
-                                        ? "bg-emerald-500/10 text-emerald-400 ring-emerald-500/20"
-                                        : "bg-yellow-500/10 text-yellow-500 ring-yellow-500/20"
-                                        }`}
-                                >
-                                    {post.status === "published" ? dict.published : dict.draft}
-                                </span>
-                            </td>
-                            <td className="px-6 py-4 text-gray-400 text-xs">
-                                {post.createdAt}
-                            </td>
-                            <td className="px-6 py-4 text-right">
-                                <div className="flex items-center justify-end gap-3 font-medium">
-                                    {post.status === "draft" ? (
+                    {posts.map((post) => {
+                        const siblings = posts.filter(p => p.slug === post.slug);
+
+                        return (
+                            <tr key={post.id} className="transition-colors hover:bg-white/[0.02]">
+                                <td className="px-6 py-4">
+                                    <div className="font-medium text-gray-100">{post.title}</div>
+                                    <div className="text-xs text-gray-500 font-mono mt-0.5">/blog/{post.slug}</div>
+                                </td>
+                                <td className="px-6 py-4">
+                                    <span className="inline-flex items-center rounded-md bg-white/10 px-2 py-1 text-xs font-medium text-gray-300 ring-1 ring-inset ring-white/10">
+                                        {post.locale.toUpperCase()}
+                                    </span>
+                                </td>
+                                <td className="px-6 py-4">
+                                    <div className="flex gap-2">
+                                        {ALL_LOCALES.map(loc => {
+                                            const existing = siblings.find(s => s.locale === loc.value);
+                                            if (existing) {
+                                                return (
+                                                    <span key={loc.value} title={loc.value.toUpperCase()} className="opacity-100 grayscale-0 filter transition-all scale-110">
+                                                        {loc.flag}
+                                                    </span>
+                                                );
+                                            }
+                                            return (
+                                                <Link
+                                                    key={loc.value}
+                                                    href={`/admin?slug=${post.slug}&targetLocale=${loc.value}&title=${encodeURIComponent(post.title)}&category=${encodeURIComponent(post.category || "")}`}
+                                                    className="opacity-30 grayscale filter hover:grayscale-0 hover:opacity-100 hover:scale-125 transition-all"
+                                                    title={`${dict.addTranslation} (${loc.value.toUpperCase()})`}
+                                                >
+                                                    {loc.flag}
+                                                </Link>
+                                            );
+                                        })}
+                                    </div>
+                                </td>
+                                <td className="px-6 py-4">
+                                    <span
+                                        className={`inline-flex items-center rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset ${post.status === "published"
+                                            ? "bg-emerald-500/10 text-emerald-400 ring-emerald-500/20"
+                                            : "bg-yellow-500/10 text-yellow-500 ring-yellow-500/20"
+                                            }`}
+                                    >
+                                        {post.status === "published" ? dict.published : dict.draft}
+                                    </span>
+                                </td>
+                                <td className="px-6 py-4 text-gray-400 text-xs">
+                                    {post.createdAt}
+                                </td>
+                                <td className="px-6 py-4 text-right">
+                                    <div className="flex items-center justify-end gap-3 font-medium">
+                                        {post.status === "draft" ? (
+                                            <button
+                                                disabled={isProcessing === post.id}
+                                                onClick={() => handleStatusChange(post, "published")}
+                                                className="text-purple-400 hover:text-purple-300 transition-colors disabled:opacity-50"
+                                            >
+                                                {dict.publish}
+                                            </button>
+                                        ) : (
+                                            <button
+                                                disabled={isProcessing === post.id}
+                                                onClick={() => handleStatusChange(post, "draft")}
+                                                className="text-gray-400 hover:text-gray-300 transition-colors disabled:opacity-50"
+                                            >
+                                                {dict.unpublish}
+                                            </button>
+                                        )}
+                                        <span className="text-white/10">|</span>
+                                        <Link
+                                            href={`/admin/edit/${post.id}`}
+                                            className="text-blue-400 hover:text-blue-300 transition-colors"
+                                        >
+                                            {dict.edit}
+                                        </Link>
+                                        <span className="text-white/10">|</span>
                                         <button
                                             disabled={isProcessing === post.id}
-                                            onClick={() => handleStatusChange(post, "published")}
-                                            className="text-purple-400 hover:text-purple-300 transition-colors disabled:opacity-50"
+                                            onClick={() => handleDelete(post.id)}
+                                            className="text-red-400 hover:text-red-300 transition-colors disabled:opacity-50"
                                         >
-                                            {dict.publish}
+                                            {dict.delete}
                                         </button>
-                                    ) : (
-                                        <button
-                                            disabled={isProcessing === post.id}
-                                            onClick={() => handleStatusChange(post, "draft")}
-                                            className="text-gray-400 hover:text-gray-300 transition-colors disabled:opacity-50"
-                                        >
-                                            {dict.unpublish}
-                                        </button>
-                                    )}
-                                    <span className="text-white/10">|</span>
-                                    <Link
-                                        href={`/admin/edit/${post.id}`}
-                                        className="text-blue-400 hover:text-blue-300 transition-colors"
-                                    >
-                                        {dict.edit}
-                                    </Link>
-                                    <span className="text-white/10">|</span>
-                                    <button
-                                        disabled={isProcessing === post.id}
-                                        onClick={() => handleDelete(post.id)}
-                                        className="text-red-400 hover:text-red-300 transition-colors disabled:opacity-50"
-                                    >
-                                        {dict.delete}
-                                    </button>
-                                </div>
-                            </td>
-                        </tr>
-                    ))}
+                                    </div>
+                                </td>
+                            </tr>
+                        );
+                    })}
                 </tbody>
             </table>
         </div>

--- a/src/app/admin/posts/posts-table.tsx
+++ b/src/app/admin/posts/posts-table.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { useState } from "react";
+import { deletePost, updatePostStatus } from "../actions";
+
+import { adminStrings } from "../i18n";
+
+type Post = {
+    id: string;
+    title: string;
+    status: "draft" | "published";
+    locale: string;
+    slug: string;
+    createdAt: string;
+};
+
+type PostsTableProps = {
+    posts: Post[];
+    dict: typeof adminStrings.en.posts;
+};
+
+export default function PostsTable({ posts, dict }: PostsTableProps) {
+    const [isProcessing, setIsProcessing] = useState<string | null>(null);
+
+    const handleStatusChange = async (post: Post, newStatus: "draft" | "published") => {
+        setIsProcessing(post.id);
+        const result = await updatePostStatus(post.id, newStatus);
+        if (result.error) alert(result.error);
+        setIsProcessing(null);
+    };
+
+    const handleDelete = async (postId: string) => {
+        if (!confirm(dict.confirmDelete)) return;
+        setIsProcessing(postId);
+        const result = await deletePost(postId);
+        if (result.error) alert(result.error);
+        setIsProcessing(null);
+    };
+
+    if (posts.length === 0) {
+        return (
+            <div className="p-12 text-center text-sm text-gray-400">
+                {dict.emptyState}
+            </div>
+        );
+    }
+
+    return (
+        <div className="overflow-x-auto">
+            <table className="w-full text-left text-sm text-gray-300">
+                <thead className="bg-white/5 text-xs font-semibold uppercase tracking-widest text-gray-400 border-b border-white/5">
+                    <tr>
+                        <th className="px-6 py-4">{dict.title}</th>
+                        <th className="px-6 py-4">{dict.locale}</th>
+                        <th className="px-6 py-4">{dict.status}</th>
+                        <th className="px-6 py-4">Date</th>
+                        <th className="px-6 py-4 text-right">{dict.actions}</th>
+                    </tr>
+                </thead>
+                <tbody className="divide-y divide-white/5">
+                    {posts.map((post) => (
+                        <tr key={post.id} className="transition-colors hover:bg-white/[0.02]">
+                            <td className="px-6 py-4">
+                                <div className="font-medium text-gray-100">{post.title}</div>
+                                <div className="text-xs text-gray-500 font-mono mt-0.5">/blog/{post.slug}</div>
+                            </td>
+                            <td className="px-6 py-4">
+                                <span className="inline-flex items-center rounded-md bg-white/10 px-2 py-1 text-xs font-medium text-gray-300 ring-1 ring-inset ring-white/10">
+                                    {post.locale.toUpperCase()}
+                                </span>
+                            </td>
+                            <td className="px-6 py-4">
+                                <span
+                                    className={`inline-flex items-center rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset ${post.status === "published"
+                                        ? "bg-emerald-500/10 text-emerald-400 ring-emerald-500/20"
+                                        : "bg-yellow-500/10 text-yellow-500 ring-yellow-500/20"
+                                        }`}
+                                >
+                                    {post.status === "published" ? dict.published : dict.draft}
+                                </span>
+                            </td>
+                            <td className="px-6 py-4 text-gray-400 text-xs">
+                                {post.createdAt}
+                            </td>
+                            <td className="px-6 py-4 text-right">
+                                <div className="flex items-center justify-end gap-3 font-medium">
+                                    {post.status === "draft" ? (
+                                        <button
+                                            disabled={isProcessing === post.id}
+                                            onClick={() => handleStatusChange(post, "published")}
+                                            className="text-purple-400 hover:text-purple-300 transition-colors disabled:opacity-50"
+                                        >
+                                            {dict.publish}
+                                        </button>
+                                    ) : (
+                                        <button
+                                            disabled={isProcessing === post.id}
+                                            onClick={() => handleStatusChange(post, "draft")}
+                                            className="text-gray-400 hover:text-gray-300 transition-colors disabled:opacity-50"
+                                        >
+                                            {dict.unpublish}
+                                        </button>
+                                    )}
+                                    <span className="text-white/10">|</span>
+                                    <button
+                                        disabled={isProcessing === post.id}
+                                        onClick={() => handleDelete(post.id)}
+                                        className="text-red-400 hover:text-red-300 transition-colors disabled:opacity-50"
+                                    >
+                                        {dict.delete}
+                                    </button>
+                                </div>
+                            </td>
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+        </div>
+    );
+}

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,0 +1,83 @@
+
+import { createSupabaseServerClient } from "./supabase-ssr";
+
+export type LogLevel = "error" | "info" | "warn" | "debug";
+
+interface LogEntry {
+    level: LogLevel;
+    module: string;
+    message: string;
+    stack?: string;
+    context?: Record<string, unknown> | unknown;
+    user_email?: string;
+    url?: string;
+}
+
+/**
+ * NeoWhisper Logger
+ * Saves logs to Supabase and optionally console
+ */
+export const logger = {
+    async log(entry: LogEntry) {
+        // 1. Always log to console in development
+        if (process.env.NODE_ENV === "development") {
+            const consoleMethod = entry.level === "error" ? "error" : entry.level === "warn" ? "warn" : "log";
+            console[consoleMethod](`[${entry.module}] ${entry.message}`, entry.context || "");
+        }
+
+        // 2. Persist to Supabase
+        try {
+            const supabase = await createSupabaseServerClient();
+
+            // Attempt to get user if on server
+            let user_email = entry.user_email;
+            if (!user_email) {
+                try {
+                    const { data: { user } } = await supabase.auth.getUser();
+                    user_email = user?.email;
+                } catch { /* Ignore if no user session */ }
+            }
+
+            await supabase.from("error_logs").insert({
+                level: entry.level,
+                module: entry.module,
+                message: entry.message,
+                stack: entry.stack,
+                context: entry.context,
+                user_email: user_email,
+                url: entry.url,
+            });
+        } catch (err) {
+            // Fail silently to avoid crashing the app due to logging failure
+            console.error("FATAL: Logging to Supabase failed.", err);
+        }
+    },
+
+    async error(module: string, message: string, error?: unknown, context?: Record<string, unknown>) {
+        return this.log({
+            level: "error",
+            module,
+            message,
+            stack: error instanceof Error ? error.stack : undefined,
+            context: context || (error instanceof Error ? { name: error.name, originalMessage: error.message } : error),
+        });
+    },
+
+    async warn(module: string, message: string, context?: Record<string, unknown>) {
+        return this.log({
+            level: "warn",
+            module,
+            message,
+            context,
+        });
+    },
+
+    async info(module: string, message: string, context?: Record<string, unknown>) {
+        return this.log({
+            level: "info",
+            module,
+            message,
+            context,
+        });
+    }
+};

--- a/src/lib/posts-hybrid.ts
+++ b/src/lib/posts-hybrid.ts
@@ -81,8 +81,8 @@ export async function getHybridPosts(locale: string): Promise<HybridPost[]> {
   ] as HybridPost[]);
 
   return combined.sort((a, b) => {
-    const aTime = new Date(a.publishedAt).getTime();
-    const bTime = new Date(b.publishedAt).getTime();
+    const aTime = a.publishedAt ? new Date(a.publishedAt).getTime() : 0;
+    const bTime = b.publishedAt ? new Date(b.publishedAt).getTime() : 0;
     return bTime - aTime;
   });
 }


### PR DESCRIPTION
## Description

This PR introduces a full content management interface for the **Admin Workspace**, allowing administrators to manage and mutate blog content directly from the website without needing to access the Supabase dashboard.

**Key features include:**

- **Manage Posts Dashboard:** Added a new `/admin/posts` table displaying all posts with their title, slug, locale, status (Draft/Published), and creation date.  
- **Publish & Unpublish Workflow:** Implemented authenticated Server Actions to instantly toggle visibility status for existing posts.  
- **Edit Capabilities:** Added dynamic routing (`/admin/edit/[id]`) that safely retrieves post content from Supabase to pre-fill the form, allowing admins to update Markdown content and meta/slug details directly from the UI.  
- **Delete Support:** Added the ability to completely delete a post and its metadata securely.  
- **Navigation & i18n:** Added dual-tab navigation in the Admin layout (New Post / Manage Posts), fixed a language switcher routing bug, and generated English and Japanese translation bindings for all new UI components.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Style/UI changes
- [ ] ♻️ Refactor (no functional changes)
- [ ] ⚡ Performance improvement

## Checklist

- [x] My code follows the project's style guidelines  
- [x] I have performed a self-review of my own code  
- [x] I have tested my changes locally  
- [x] My changes generate no new warnings  
- [x] I have updated the documentation accordingly  

## Screenshots (if applicable)

<!-- Add screenshots of the new Posts Table and the Edit form UI here -->

## Related Issues

<!-- Link any related issues: Fixes #123, Closes #456 -->
