### PR TITLE
fix(contact): add turnstile guard and clarify trust copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,9 @@ This release completes all critical requirements for Google AdSense approval.
 * Admin Dashboard: Added a new "Error Logs" management page (`/admin/logs`) to review system errors recorded in the database.
 * Refactoring: Satisfied React linting rules by decoupling data fetching from JSX construction in dynamic blog pages.
 * Observability: Added standardized client and server-side logging for all admin actions (create, update, delete, status change).
+* Trust copy (JA): Replaced ambiguous "登録済み" business claims with clearer legal phrasing based on 開業届提出済み status in `about` and `AuthorBio`.
+* Contact UX: Added client-side Turnstile token guard with localized error messages (EN/JA/AR) to avoid noisy failed submissions when captcha is not completed.
+* Cross-reference: Builds on the CSP and header cleanup from merged branch `fix/changelog-fonts-tests-refactor`.
 
 ## [1.6.0] - 2026-02-07
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,12 @@ This site uses a Content Security Policy to allow Google AdSense, Analytics, and
 - AdSense: `pagead2.googlesyndication.com`, `googleads.g.doubleclick.net`, `tpc.googlesyndication.com`, `*.google.com`, `adtrafficquality.google`, `*.adtrafficquality.google`, `fundingchoicesmessages.google.com`
 - Turnstile: `challenges.cloudflare.com`
 
+## 🧩 Turnstile Troubleshooting
+
+- If DevTools shows `TurnstileError: 110200` with repeated `400` requests to `challenges.cloudflare.com`, your current hostname is not allowed for the widget key.
+- In Cloudflare Turnstile dashboard, add all active hostnames (for example: `localhost`, `127.0.0.1`, your production domain, and preview domains if used).
+- Keep widget key/secret key pairs matched by environment. Use separate widget keys for local/dev and production.
+
 ## 🚀 Deploy on Vercel
 
 Push to your main branch and connect to [Vercel](https://vercel.com/new) for automatic deployments.

--- a/src/app/(site)/about/page.tsx
+++ b/src/app/(site)/about/page.tsx
@@ -29,14 +29,14 @@ const translations = {
   },
   ja: {
     label: "概要",
-    title: "登録済みITサービス事業",
+    title: "ITサービス個人事業",
     subtitle: "開業届上の職業区分: ITサービス業。",
-    intro: "NEO WHISPERは、2025年12月に東京都港区にてアルカーディ　ヨセフにより設立された、ITサービスを提供する登録済みの個人事業主です。",
+    intro: "NEO WHISPERは、2025年12月に東京都港区でアルカーディ ヨセフが開業したITサービス個人事業です。税務署へ開業届を提出済みです。",
     back: "ホームへ戻る",
     sections: [
       {
         title: "私たちについて",
-        copy: "東京都港区を拠点に、日本語・英語・アラビア語の3言語で提供する、登録済みのITサービス個人事業です。"
+        copy: "東京都港区を拠点に、税務署へ開業届を提出済みの個人事業として、日本語・英語・アラビア語の3言語でITサービスを提供しています。"
       },
       {
         title: "事業内容",
@@ -92,9 +92,9 @@ export async function generateMetadata({
         "Registered IT services sole proprietorship in Tokyo. Service scope includes software development, game development, app development, web production, web content production, and translation.",
     },
     ja: {
-      title: "概要 - NeoWhisper | 登録済みITサービス事業",
+      title: "概要 - NeoWhisper | ITサービス個人事業",
       description:
-        "NeoWhisperは東京都港区の登録済みITサービス個人事業主です。ソフトウェア開発・ゲーム開発・アプリ開発・Web制作・Webコンテンツ制作・翻訳などを提供します。",
+        "NeoWhisperは東京都港区を拠点とするITサービス個人事業主です。税務署へ開業届を提出済みで、ソフトウェア開発・ゲーム開発・アプリ開発・Web制作・Webコンテンツ制作・翻訳などを提供します。",
     },
     ar: {
       title: "عن NeoWhisper | نشاط خدمات تقنية معلومات",

--- a/src/app/(site)/contact/page.tsx
+++ b/src/app/(site)/contact/page.tsx
@@ -22,6 +22,8 @@ const translations = {
       sending: "Sending...",
       success: "Thanks! Your message has been received.",
       error: "Something went wrong. Please try again.",
+      turnstileRequired:
+        "Please complete spam verification and submit again.",
       viewConfirmation: "View confirmation",
       placeholderName: "Your full name",
       placeholderEmail: "you@email.com",
@@ -57,6 +59,8 @@ const translations = {
       sending: "送信中...",
       success: "送信ありがとうございます。内容を確認します。",
       error: "送信に失敗しました。時間をおいて再度お試しください。",
+      turnstileRequired:
+        "スパム対策の認証を完了してから、もう一度送信してください。",
       viewConfirmation: "送信内容を確認",
       placeholderName: "お名前",
       placeholderEmail: "you@email.com",
@@ -97,6 +101,8 @@ const translations = {
       sending: "جاري الإرسال...",
       success: "تم استلام رسالتك بنجاح.",
       error: "حدث خطأ. يرجى المحاولة مرة أخرى.",
+      turnstileRequired:
+        "يرجى إكمال تحقق مكافحة الرسائل المزعجة ثم إعادة الإرسال.",
       viewConfirmation: "عرض التأكيد",
       placeholderName: "اسمك الكامل",
       placeholderEmail: "you@email.com",

--- a/src/components/AuthorBio.tsx
+++ b/src/components/AuthorBio.tsx
@@ -34,7 +34,7 @@ const content: Record<string, AuthorContent> = {
   },
   ja: {
     title: "著者について",
-    bio: "NeoWhisperは東京都港区を拠点とする登録済みITサービス事業です。ソフトウェア開発・ゲーム開発・アプリ開発・Web/コンテンツ制作・翻訳サービスを提供しています。",
+    bio: "NeoWhisperは東京都港区を拠点とする個人事業主です。税務署へ開業届を提出済みで、ソフトウェア開発・ゲーム開発・アプリ開発・Web/コンテンツ制作・翻訳サービスを提供しています。",
     expertise:
       "専門分野: Next.js • TypeScript • React • Node.js • 多言語サイト • SEO • パフォーマンス最適化",
     cta: "お問い合わせ",

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -15,6 +15,7 @@ type ContactCopy = {
   sending: string;
   success: string;
   error: string;
+  turnstileRequired: string;
   viewConfirmation: string;
   placeholderName: string;
   placeholderEmail: string;
@@ -58,6 +59,15 @@ export default function ContactForm({
       turnstileToken: formData.get("cf-turnstile-response"),
       lang: formData.get("lang"),
     };
+
+    if (
+      turnstileSiteKey &&
+      (typeof payload.turnstileToken !== "string" || payload.turnstileToken.trim() === "")
+    ) {
+      setState("error");
+      setMessage(copy.turnstileRequired);
+      return;
+    }
 
     try {
       const res = await fetch("/api/contact", {

--- a/src/components/SiteFooter.tsx
+++ b/src/components/SiteFooter.tsx
@@ -53,7 +53,7 @@ function getSectionLabel(
     ja: {
       trustSignals: "信頼情報",
       links: "リンク",
-      registration: "東京都港区で正式登録済み",
+      registration: "東京都港区を拠点に開業届提出済み",
       businessType: "職業区分: ITサービス業",
     },
     ar: {
@@ -76,7 +76,7 @@ function getBusinessText(lang: SupportedLang) {
         "Service scope: software development, game development, app development, web production, web content production, and translation. Based in Minato City, Tokyo.",
     },
     ja: {
-      line1: "日本で登録された個人事業主です（職業: ITサービス業）。",
+      line1: "日本で開業届を提出済みの個人事業主です（職業: ITサービス業）。",
       line2:
         "事業概要: ソフトウェア開発・ゲーム開発・アプリ開発・Web制作・Webコンテンツ制作・翻訳などのITサービス提供。拠点は東京都港区です。",
     },


### PR DESCRIPTION
## Description

Improves contact form reliability and trust-language clarity.

### Changes included
- Added a client-side Turnstile token guard so submit is blocked with a clear message when captcha is not completed.
- Added localized Turnstile-required error copy in EN/JA/AR.
- Replaced ambiguous Japanese trust wording (`登録済み`) with clearer legal phrasing (`開業届提出済み`) across:
  - About page
  - Author bio
  - Footer trust signals
- Added a Turnstile troubleshooting section to README (error `110200`, hostname allowlist, env key pairing).
- Updated CHANGELOG (`Unreleased`) with these items.

### Why
- Prevent avoidable failed submissions/noisy errors when Turnstile token is missing.
- Make business trust copy more precise and natural in Japanese.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 📝 Documentation update
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🎨 Style/UI changes
- [ ] ♻️ Refactor (no functional changes)
- [ ] ⚡ Performance improvement

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have tested my changes locally
- [ ] My changes generate no new warnings
- [x] I have updated the documentation accordingly

Notes:
- `npm run lint` passed.
- Existing Turnstile/PAT console warnings are external challenge-platform noise and not introduced by this PR.
- In this environment, `npm test` reports a pre-existing Next/Node unhandled rejection after tests complete.

## Screenshots (if applicable)

Optional: attach the contact page screenshot with Turnstile success state and console output context.

## Related Issues

Builds on the merged CSP/header cleanup from `fix/changelog-fonts-tests-refactor`.
