### PR TITLE
fix(security): prevent wildcard ACAO fallback on metadata routes

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -107,9 +107,6 @@ function applyMetadataCorsFix(request: NextRequest, response: NextResponse) {
     return;
   }
 
-  const vary = response.headers.get("Vary");
-  response.headers.set("Vary", vary ? `${vary}, Origin` : "Origin");
-
   const allowedOrigins = new Set([
     "https://www.neowhisper.net",
     "https://neowhisper.net",
@@ -118,10 +115,16 @@ function applyMetadataCorsFix(request: NextRequest, response: NextResponse) {
 
   if (requestOrigin && allowedOrigins.has(requestOrigin)) {
     response.headers.set("Access-Control-Allow-Origin", requestOrigin);
+    const vary = response.headers.get("Vary");
+    response.headers.set("Vary", vary ? `${vary}, Origin` : "Origin");
     return;
   }
 
-  response.headers.delete("Access-Control-Allow-Origin");
+  // Some metadata routes can re-add a permissive ACAO later if absent.
+  // Set an explicit non-wildcard fallback to prevent `*` from appearing.
+  response.headers.set("Access-Control-Allow-Origin", "https://www.neowhisper.net");
+  const vary = response.headers.get("Vary");
+  response.headers.set("Vary", vary ? `${vary}, Origin` : "Origin");
 }
 
 function addNonceToRequestHeaders(

--- a/tests/cors.spec.ts
+++ b/tests/cors.spec.ts
@@ -1,27 +1,40 @@
 import { test, expect } from "@playwright/test";
 
-// Ensure static resources do not send Access-Control-Allow-Origin headers.
-// This prevents accidental broad CORS exposure for robots/sitemap.
-// Note: Next.js doesn't allow complete header removal, so we accept empty string as valid.
-
-test("robots.txt and sitemap.xml do not include ACAO header", async ({
+// Ensure metadata resources never return wildcard ACAO and are restricted
+// to trusted origins only.
+test("robots.txt and sitemap.xml use restricted ACAO policy", async ({
   request,
 }) => {
-  const origin = "https://malicious.example";
+  const trustedOrigin = "https://www.neowhisper.net";
+  const untrustedOrigin = "https://malicious.example";
 
-  const robots = await request.get("/robots.txt", {
-    headers: { Origin: origin },
+  const robotsTrusted = await request.get("/robots.txt", {
+    headers: { Origin: trustedOrigin },
   });
-  const robotsHeaders = robots.headers();
-  // Accept undefined or empty string (Next.js limitation - can't remove, only override)
-  const robotsAcao = robotsHeaders["access-control-allow-origin"];
-  expect(robotsAcao === undefined || robotsAcao === "").toBe(true);
+  expect(robotsTrusted.headers()["access-control-allow-origin"]).toBe(
+    trustedOrigin,
+  );
 
-  const sitemap = await request.get("/sitemap.xml", {
-    headers: { Origin: origin },
+  const robotsUntrusted = await request.get("/robots.txt", {
+    headers: { Origin: untrustedOrigin },
   });
-  const sitemapHeaders = sitemap.headers();
-  // Accept undefined or empty string (Next.js limitation - can't remove, only override)
-  const sitemapAcao = sitemapHeaders["access-control-allow-origin"];
-  expect(sitemapAcao === undefined || sitemapAcao === "").toBe(true);
+  const robotsUntrustedAcao =
+    robotsUntrusted.headers()["access-control-allow-origin"];
+  expect(robotsUntrustedAcao).toBe("https://www.neowhisper.net");
+  expect(robotsUntrustedAcao).not.toBe("*");
+
+  const sitemapTrusted = await request.get("/sitemap.xml", {
+    headers: { Origin: trustedOrigin },
+  });
+  expect(sitemapTrusted.headers()["access-control-allow-origin"]).toBe(
+    trustedOrigin,
+  );
+
+  const sitemapUntrusted = await request.get("/sitemap.xml", {
+    headers: { Origin: untrustedOrigin },
+  });
+  const sitemapUntrustedAcao =
+    sitemapUntrusted.headers()["access-control-allow-origin"];
+  expect(sitemapUntrustedAcao).toBe("https://www.neowhisper.net");
+  expect(sitemapUntrustedAcao).not.toBe("*");
 });


### PR DESCRIPTION
## Description

Fixes an edge case in metadata CORS handling where `/robots.txt` could still return `Access-Control-Allow-Origin: *` for untrusted origins.

### What changed
- Updated metadata CORS logic in `src/proxy.ts` (`applyMetadataCorsFix`):
  - Keep explicit allowlist behavior for trusted origins:
    - `https://www.neowhisper.net`
    - `https://neowhisper.net`
  - For all other origins, set a strict non-wildcard fallback:
    - `Access-Control-Allow-Origin: https://www.neowhisper.net`
  - Keep `Vary: Origin` to avoid cache mixing across origins.

### Why
- Previous behavior could delete ACAO for untrusted origins, but some metadata route behavior could reintroduce permissive `*`.
- This patch prevents wildcard ACAO from appearing on metadata routes and aligns with the scanner finding.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Style/UI changes
- [ ] ♻️ Refactor (no functional changes)
- [ ] ⚡ Performance improvement

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have tested my changes locally
- [x] My changes generate no new warnings
- [ ] I have updated the documentation accordingly

## Screenshots (if applicable)

N/A (header behavior change only)

## Related Issues

Follow-up fix for security scan finding:
- Access-Control-Allow-Origin misconfiguration on metadata endpoints (`/robots.txt`, `/sitemap.xml`)
