### PR TITLE
fix(security): suppress metadata ACAO for untrusted origins

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -125,8 +125,8 @@ function applyMetadataCorsFix(request: NextRequest, response: NextResponse) {
   }
 
   // Some metadata routes can re-add a permissive ACAO later if absent.
-  // Set an explicit non-wildcard fallback to prevent `*` from appearing.
-  response.headers.set("Access-Control-Allow-Origin", "https://www.neowhisper.net");
+  // Keep ACAO explicitly empty to avoid wildcard fallback while denying CORS.
+  response.headers.set("Access-Control-Allow-Origin", "");
   const vary = response.headers.get("Vary");
   response.headers.set("Vary", vary ? `${vary}, Origin` : "Origin");
 }

--- a/tests/cors.spec.ts
+++ b/tests/cors.spec.ts
@@ -20,7 +20,9 @@ test("robots.txt and sitemap.xml use restricted ACAO policy", async ({
   });
   const robotsUntrustedAcao =
     robotsUntrusted.headers()["access-control-allow-origin"];
-  expect(robotsUntrustedAcao).toBe("https://www.neowhisper.net");
+  expect(robotsUntrustedAcao === undefined || robotsUntrustedAcao === "").toBe(
+    true,
+  );
   expect(robotsUntrustedAcao).not.toBe("*");
 
   const sitemapTrusted = await request.get("/sitemap.xml", {
@@ -35,6 +37,8 @@ test("robots.txt and sitemap.xml use restricted ACAO policy", async ({
   });
   const sitemapUntrustedAcao =
     sitemapUntrusted.headers()["access-control-allow-origin"];
-  expect(sitemapUntrustedAcao).toBe("https://www.neowhisper.net");
+  expect(
+    sitemapUntrustedAcao === undefined || sitemapUntrustedAcao === "",
+  ).toBe(true);
   expect(sitemapUntrustedAcao).not.toBe("*");
 });


### PR DESCRIPTION
## Description

Fixes metadata-route CORS fallback behavior so `/robots.txt` and `/sitemap.xml` do not return a non-empty `Access-Control-Allow-Origin` for untrusted/no-origin requests, while preserving trusted-origin behavior for site origins.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Style/UI changes
- [ ] ♻️ Refactor (no functional changes)
- [ ] ⚡ Performance improvement

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have tested my changes locally
- [x] My changes generate no new warnings
- [ ] I have updated the documentation accordingly

## Screenshots (if applicable)

N/A (no UI changes)

## Related Issues

Closes #1 
