### PR TITLE
feat(content-automation): make daily trend category dynamic

### DIFF
--- a/scripts/generate-daily-ai-trend-posts.mjs
+++ b/scripts/generate-daily-ai-trend-posts.mjs
@@ -63,6 +63,126 @@ const TREND_KEYWORDS = [
   "api",
 ];
 
+const CATEGORY_DEFINITIONS = [
+  {
+    slug: "software-development",
+    nameEn: "Software Development",
+    nameJa: "Software Development",
+    nameAr: "Software Development",
+    keywords: ["developer", "engineering", "software", "coding", "codebase", "framework", "sdk", "api"],
+  },
+  {
+    slug: "game-development",
+    nameEn: "Game Development",
+    nameJa: "Game Development",
+    nameAr: "Game Development",
+    keywords: ["game", "gaming", "unity", "unreal", "rendering", "simulation"],
+  },
+  {
+    slug: "translation",
+    nameEn: "Translation",
+    nameJa: "Translation",
+    nameAr: "Translation",
+    keywords: ["translation", "localization", "multilingual", "i18n", "l10n", "language"],
+  },
+  {
+    slug: "next.js",
+    nameEn: "Next.js Tutorials",
+    nameJa: "Next.js Tutorials",
+    nameAr: "Next.js Tutorials",
+    keywords: ["next.js", "nextjs", "vercel", "app router", "route handlers"],
+  },
+  {
+    slug: "typescript",
+    nameEn: "TypeScript",
+    nameJa: "TypeScript",
+    nameAr: "TypeScript",
+    keywords: ["typescript", "type safety", "types", "tsconfig", "eslint", "compiler"],
+  },
+  {
+    slug: "tech-tips",
+    nameEn: "Tech Tips",
+    nameJa: "Tech Tips",
+    nameAr: "Tech Tips",
+    keywords: ["how to", "guide", "checklist", "debugging", "tips", "playbook", "best practices"],
+  },
+  {
+    slug: "art-design",
+    nameEn: "Art & Design",
+    nameJa: "アート＆デザイン",
+    nameAr: "الفن والتصميم",
+    keywords: ["design", "ux", "ui", "visual", "typography", "illustration", "creative"],
+  },
+  {
+    slug: "product-strategy",
+    nameEn: "Product Strategy",
+    nameJa: "プロダクト戦略",
+    nameAr: "استراتيجية المنتج",
+    keywords: [
+      "strategy",
+      "roadmap",
+      "product team",
+      "go to market",
+      "regulation",
+      "policy",
+      "adoption",
+      "trend",
+      "impact",
+    ],
+  },
+];
+
+const CATEGORY_MAP = new Map(CATEGORY_DEFINITIONS.map((category) => [category.slug, category]));
+const DEFAULT_CATEGORY_SLUG = "product-strategy";
+
+function normalizeSearchText(value) {
+  return String(value || "")
+    .toLowerCase()
+    .replace(/[^a-z0-9.+\s-]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function scoreCategoryFromText(text) {
+  const normalized = normalizeSearchText(text);
+  if (!normalized) return null;
+
+  let winner = null;
+  let bestScore = 0;
+  for (const category of CATEGORY_DEFINITIONS) {
+    let score = 0;
+    for (const keyword of category.keywords) {
+      if (normalized.includes(keyword)) {
+        score += 1;
+      }
+    }
+    if (score > bestScore) {
+      bestScore = score;
+      winner = category;
+    }
+  }
+  return winner;
+}
+
+function pickCategory(content, sources) {
+  const rawSlug = String(content?.categorySlug || "").trim().toLowerCase();
+  if (CATEGORY_MAP.has(rawSlug)) {
+    return CATEGORY_MAP.get(rawSlug);
+  }
+
+  const aggregateText = [
+    content?.en?.title || "",
+    content?.en?.excerpt || "",
+    content?.en?.body || "",
+    ...sources.map((source) => `${source.title} ${source.summary}`),
+  ].join("\n");
+  const heuristicCategory = scoreCategoryFromText(aggregateText);
+  if (heuristicCategory) {
+    return heuristicCategory;
+  }
+  return CATEGORY_MAP.get(DEFAULT_CATEGORY_SLUG);
+}
+
 function decodeEntities(value) {
   return value
     .replace(/<!\[CDATA\[([\s\S]*?)\]\]>/g, "$1")
@@ -395,6 +515,7 @@ async function callChatCompletionsEndpoint(systemPrompt, userPrompt) {
 }
 
 async function createDraftContent({ dateString, sources }) {
+  const allowedCategoryList = CATEGORY_DEFINITIONS.map((category) => category.slug).join(", ");
   const systemPrompt = [
     "You are a senior multilingual tech editor.",
     "Write high-trust, human-sounding blog content in English, Japanese, and Arabic.",
@@ -418,9 +539,11 @@ async function createDraftContent({ dateString, sources }) {
     "- Do not use a bullet list instead of the takeaway table.",
     "- Include exact dates when mentioning events.",
     "- Do not include a references section; it will be appended automatically.",
+    `- Pick exactly one category slug from this list: ${allowedCategoryList}.`,
     "",
     "Output schema:",
     "{",
+    `  "categorySlug": "one of: ${allowedCategoryList}",`,
     '  "slugSuffix": "3-5 ascii words, lowercase, hyphen-separated",',
     '  "en": { "title": "...", "excerpt": "...", "body": "markdown" },',
     '  "ja": { "title": "...", "excerpt": "...", "body": "markdown" },',
@@ -608,6 +731,12 @@ async function main() {
     throw new Error("Model output is missing required language blocks");
   }
   validateDraftContent(content);
+  const selectedCategory =
+    pickCategory(content, selectedSources) ||
+    CATEGORY_MAP.get(DEFAULT_CATEGORY_SLUG) ||
+    CATEGORY_DEFINITIONS[0];
+  const selectedCategorySlug = selectedCategory.slug || DEFAULT_CATEGORY_SLUG;
+  console.log(`[daily-trends] selected category: ${selectedCategorySlug}`);
 
   const baseSlug = await chooseBaseSlug(dateString, content.slugSuffix);
   if (!baseSlug) {
@@ -619,12 +748,12 @@ async function main() {
     {
       lang: "en",
       path: path.join(POSTS_DIR, `${baseSlug}.mdx`),
-      category: "Product Strategy",
+      category: selectedCategory.nameEn,
       body: buildPostDocument({
         title: content.en.title,
         excerpt: content.en.excerpt,
         dateString,
-        category: "Product Strategy",
+        category: selectedCategory.nameEn,
         body: content.en.body,
         referencesSection: buildReferencesSection("en", selectedSources),
       }),
@@ -632,12 +761,12 @@ async function main() {
     {
       lang: "ja",
       path: path.join(POSTS_DIR, `${baseSlug}-ja.mdx`),
-      category: "プロダクト戦略",
+      category: selectedCategory.nameJa || selectedCategory.nameEn,
       body: buildPostDocument({
         title: content.ja.title,
         excerpt: content.ja.excerpt,
         dateString,
-        category: "プロダクト戦略",
+        category: selectedCategory.nameJa || selectedCategory.nameEn,
         body: content.ja.body,
         referencesSection: buildReferencesSection("ja", selectedSources),
       }),
@@ -645,12 +774,12 @@ async function main() {
     {
       lang: "ar",
       path: path.join(POSTS_DIR, `${baseSlug}-ar.mdx`),
-      category: "استراتيجية المنتج",
+      category: selectedCategory.nameAr || selectedCategory.nameEn,
       body: buildPostDocument({
         title: content.ar.title,
         excerpt: content.ar.excerpt,
         dateString,
-        category: "استراتيجية المنتج",
+        category: selectedCategory.nameAr || selectedCategory.nameEn,
         body: content.ar.body,
         referencesSection: buildReferencesSection("ar", selectedSources),
       }),


### PR DESCRIPTION
## Summary

Makes daily AI trend category selection dynamic instead of hardcoded.

## Changes

- Added allowed category definitions/slugs for automation.
- Updated prompt schema to ask model for `categorySlug`.
- Added validation and fallback selection logic:
  1. Use valid model `categorySlug`.
  2. Fallback to keyword-based heuristic from generated content/sources.
  3. Final fallback to `product-strategy`.
- Writes localized category labels to EN/JA/AR frontmatter based on selected slug.

## Verification

- `node --check scripts/generate-daily-ai-trend-posts.mjs`
- Lint passed during commit hook.
