### PR TITLE
feat(policy): enforce >700-word new posts + update privacy disclosures

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,2 @@
 npm run lint
+node scripts/check-new-post-length.mjs

--- a/scripts/check-new-post-length.mjs
+++ b/scripts/check-new-post-length.mjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+
+const MIN_WORDS_EXCLUSIVE = 700; // Rule: strictly more than 700 words
+const POSTS_DIR = "src/content/posts";
+
+function stripFrontmatter(source) {
+  if (!source.startsWith("---")) return source;
+  const endIndex = source.indexOf("\n---", 3);
+  if (endIndex === -1) return source;
+  return source.slice(endIndex + 4);
+}
+
+function countWords(markdown) {
+  return markdown
+    .replace(/```[\s\S]*?```/g, " ")
+    .replace(/`[^`]*`/g, " ")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .split(" ")
+    .filter(Boolean).length;
+}
+
+function parseAddedPostFiles(diffOutput) {
+  return diffOutput
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => line.split("\t"))
+    .filter(([status, filePath]) => status === "A" && typeof filePath === "string")
+    .map(([, filePath]) => filePath)
+    .filter((filePath) => filePath.startsWith(`${POSTS_DIR}/`) && filePath.endsWith(".mdx"));
+}
+
+async function getStagedAddedFiles() {
+  const { execSync } = await import("node:child_process");
+  const output = execSync("git diff --cached --name-status --diff-filter=A", {
+    encoding: "utf8",
+  });
+  return parseAddedPostFiles(output);
+}
+
+async function main() {
+  const addedPosts = await getStagedAddedFiles();
+  if (addedPosts.length === 0) {
+    process.exit(0);
+  }
+
+  const failures = [];
+
+  for (const relativeFile of addedPosts) {
+    const absoluteFile = path.join(process.cwd(), relativeFile);
+    const content = await fs.readFile(absoluteFile, "utf8");
+    const body = stripFrontmatter(content);
+    const wordCount = countWords(body);
+
+    if (wordCount <= MIN_WORDS_EXCLUSIVE) {
+      failures.push({
+        file: relativeFile,
+        wordCount,
+      });
+    }
+  }
+
+  if (failures.length === 0) {
+    process.exit(0);
+  }
+
+  console.error("Post length rule failed. New posts must be more than 700 words.");
+  for (const failure of failures) {
+    console.error(`- ${failure.file}: ${failure.wordCount} words`);
+  }
+  console.error("Please expand the post(s) and commit again.");
+  process.exit(1);
+}
+
+main().catch((error) => {
+  console.error("[check-new-post-length] failed:", error?.message || error);
+  process.exit(1);
+});

--- a/scripts/generate-daily-ai-trend-posts.mjs
+++ b/scripts/generate-daily-ai-trend-posts.mjs
@@ -18,6 +18,7 @@ const API_KEY = process.env.OPENAI_API_KEY || "sk-local";
 
 const FORCE = process.argv.includes("--force");
 const DRY_RUN = process.argv.includes("--dry-run");
+const MIN_WORDS_EXCLUSIVE = 700; // Rule: strictly more than 700 words
 
 const FEEDS = [
   {
@@ -411,7 +412,7 @@ async function createDraftContent({ dateString, sources }) {
     "Create one multilingual trend brief with these requirements:",
     "- Theme: latest AI + IT practical trends for builders and product teams.",
     "- Provide EN/JA/AR versions aligned in meaning (not literal translation).",
-    "- Each body should be 500-800 words.",
+    "- Each body must be more than 700 words.",
     "- Use markdown H2 headings for trend sections with this pattern: `## 1. Trend name`.",
     "- Include 3-6 trend sections, each with exact dates and concrete product/team impact.",
     "- End with a Takeaways section containing a 3-column markdown table (Trend | What It Means for Your Team | Practical Steps).",
@@ -467,6 +468,17 @@ function hasMarkdownTable(markdownBody) {
   return /^\|.+\|\s*$/m.test(body) && /^\|[\s:\-|]+\|\s*$/m.test(body);
 }
 
+function countWords(markdownBody) {
+  return String(markdownBody || "")
+    .replace(/```[\s\S]*?```/g, " ")
+    .replace(/`[^`]*`/g, " ")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .split(" ")
+    .filter(Boolean).length;
+}
+
 function validateDraftContent(content) {
   const languages = ["en", "ja", "ar"];
 
@@ -487,9 +499,15 @@ function validateDraftContent(content) {
     }
 
     const headingCount = countTrendHeadings(block.body);
+    const wordCount = countWords(block.body);
     if (headingCount < 3) {
       throw new Error(
         `Model output for ${lang}.body has ${headingCount} trend headings; expected at least 3 with '## 1.' style.`,
+      );
+    }
+    if (wordCount <= MIN_WORDS_EXCLUSIVE) {
+      throw new Error(
+        `Model output for ${lang}.body has ${wordCount} words; expected more than ${MIN_WORDS_EXCLUSIVE}.`,
       );
     }
     if (!hasMarkdownTable(block.body)) {

--- a/src/app/(site)/privacy/page.tsx
+++ b/src/app/(site)/privacy/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import { normalizeLang, type SupportedLang } from "@/lib/i18n";
 
-const LAST_UPDATED = "2026-02-16";
+const LAST_UPDATED = "2026-03-25";
 const baseUrl = "https://www.neowhisper.net";
 
 const copyByLang: Record<
@@ -21,7 +21,9 @@ const copyByLang: Record<
     points: [
       "NeoWhisper collects only the information necessary to operate this site, respond to inquiries, and deliver requested IT services. We do not sell personal data.",
       "Contact form data (name, email, company, project details) is used only for project communication and service delivery. Data is sent over HTTPS and processed by service providers used for email and spam prevention.",
-      "Analytics and advertising tools (such as Google Analytics and Google AdSense, when enabled) may use cookies for measurement and ad delivery. You can control cookies through browser settings.",
+      "Third-party vendors, including Google, may use cookies to serve ads based on a user's prior visits to this website or other websites.",
+      "Google's use of advertising cookies enables Google and its partners to serve ads to users based on their visit to this site and/or other sites on the Internet.",
+      "Users may opt out of personalized advertising by visiting Google Ads Settings: https://adssettings.google.com. You can also manage cookies through your browser settings.",
       "If you need data access, correction, or deletion, contact neowhisperhq@gmail.com.",
     ],
   },
@@ -32,7 +34,9 @@ const copyByLang: Record<
     points: [
       "NeoWhisperは、サイト運営・お問い合わせ対応・ITサービス提供に必要な範囲でのみ情報を取得します。個人データを販売することはありません。",
       "お問い合わせフォームで送信された情報（氏名・メール・会社名・相談内容）は、案件対応および連絡目的でのみ利用します。送信はHTTPSで保護され、メール配信やスパム対策に利用する外部サービスで処理されます。",
-      "Google AnalyticsやGoogle AdSense（有効時）などの計測・広告ツールがCookieを利用する場合があります。Cookieはブラウザ設定で管理できます。",
+      "Googleを含む第三者配信事業者は、ユーザーの本サイトまたは他サイトへの過去のアクセス情報に基づいて、Cookieを使用して広告を配信する場合があります。",
+      "Googleの広告Cookieにより、Googleおよびそのパートナーは、ユーザーの本サイトまたはインターネット上の他サイトへのアクセス情報に基づいた広告を表示できます。",
+      "ユーザーは Google 広告設定（https://adssettings.google.com）でパーソナライズ広告を無効化できます。Cookieはブラウザ設定からも管理できます。",
       "開示・訂正・削除のご依頼は、neowhisperhq@gmail.com までご連絡ください。",
     ],
   },
@@ -43,7 +47,9 @@ const copyByLang: Record<
     points: [
       "يجمع NeoWhisper فقط البيانات اللازمة لتشغيل الموقع، والرد على الاستفسارات، وتقديم خدمات تقنية المعلومات المطلوبة. لا نقوم ببيع البيانات الشخصية.",
       "بيانات نموذج التواصل (الاسم، البريد، الشركة، تفاصيل المشروع) تُستخدم فقط للتواصل وتنفيذ الخدمة. يتم الإرسال عبر HTTPS وتُعالج البيانات لدى مزودي خدمة البريد والحماية من الرسائل المزعجة.",
-      "قد تستخدم أدوات التحليلات والإعلانات مثل Google Analytics وGoogle AdSense (عند التفعيل) ملفات تعريف الارتباط لأغراض القياس وعرض الإعلانات. يمكنك إدارة الكوكيز من إعدادات المتصفح.",
+      "قد يستخدم مزودو الإعلانات من الجهات الخارجية، بما في ذلك Google، ملفات تعريف الارتباط لعرض الإعلانات بناءً على زيارات المستخدم السابقة لهذا الموقع أو لمواقع أخرى.",
+      "يسمح استخدام Google لملفات تعريف ارتباط الإعلانات لـ Google وشركائها بعرض إعلانات مخصصة وفقًا لزيارة المستخدم لهذا الموقع و/أو لمواقع أخرى على الإنترنت.",
+      "يمكن للمستخدمين إيقاف الإعلانات المخصصة عبر إعدادات إعلانات Google: https://adssettings.google.com. كما يمكن إدارة ملفات تعريف الارتباط من إعدادات المتصفح.",
       "لطلب الوصول إلى بياناتك أو تعديلها أو حذفها، راسلنا على neowhisperhq@gmail.com.",
     ],
   },


### PR DESCRIPTION
## Summary
- Enforce a strict `>700 words` rule for newly added post files via pre-commit
- Enforce the same minimum in daily AI post generation prompt + validation
- Update privacy policy disclosures (EN/JA/AR) with clearer Google/third-party cookie/ad personalization language

## Files
- .husky/pre-commit
- scripts/check-new-post-length.mjs
- scripts/generate-daily-ai-trend-posts.mjs
- src/app/(site)/privacy/page.tsx

## Validation
- npm run lint
- npm run build