### PR TITLE
feat(ci): add dev-to-main promotion workflow

### DIFF
--- a/.github/workflows/promote-dev-to-main.yml
+++ b/.github/workflows/promote-dev-to-main.yml
@@ -1,0 +1,86 @@
+name: Promote Dev to Main PR
+
+on:
+  push:
+    branches:
+      - dev
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: promote-dev-to-main
+  cancel-in-progress: false
+
+jobs:
+  ensure-promotion-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ensure open PR from dev to main
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const base = "main";
+            const head = "dev";
+            const headRef = `${owner}:${head}`;
+
+            const existing = await github.paginate(github.rest.pulls.list, {
+              owner,
+              repo,
+              state: "open",
+              base,
+              head: headRef,
+              per_page: 100,
+            });
+
+            if (existing.length > 0) {
+              core.info(`Existing open promotion PR found: #${existing[0].number}`);
+              return;
+            }
+
+            const comparison = await github.rest.repos.compareCommits({
+              owner,
+              repo,
+              base,
+              head,
+            });
+
+            if ((comparison.data.ahead_by || 0) === 0) {
+              core.info("No commits to promote from dev to main.");
+              return;
+            }
+
+            const created = await github.rest.pulls.create({
+              owner,
+              repo,
+              title: "chore(release): promote dev to main",
+              head,
+              base,
+              body: [
+                "## Description",
+                "",
+                "Automated promotion PR to release the latest changes from `dev` into `main`.",
+                "",
+                "## Notes",
+                "",
+                "- Created automatically by `.github/workflows/promote-dev-to-main.yml`.",
+                "- This PR will continue to update as new commits are added to `dev`.",
+              ].join("\n"),
+            });
+
+            core.info(`Created promotion PR: #${created.data.number}`);
+
+            try {
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number: created.data.number,
+                labels: ["automated", "release"],
+              });
+            } catch (error) {
+              core.warning(`Could not add labels automatically: ${error.message}`);
+            }


### PR DESCRIPTION
## Description

Adds a new GitHub Actions workflow to automatically ensure there is an open promotion PR from `dev` to `main` whenever `dev` receives new commits.

- New workflow: `.github/workflows/promote-dev-to-main.yml`
- Trigger: `push` on `dev` and `workflow_dispatch`
- Behavior: opens `dev -> main` PR only when no open PR exists and `dev` is ahead of `main`
- Includes labeling attempt (`automated`, `release`) similar to existing promotion style

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Style/UI changes
- [ ] ♻️ Refactor (no functional changes)
- [ ] ⚡ Performance improvement

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have tested my changes locally
- [x] My changes generate no new warnings
- [ ] I have updated the documentation accordingly

## Screenshots (if applicable)

N/A

## Related Issues

N/A
