### PR TITLE
test: add site-url smoke checks and source fallback diagnostics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Test Content Generator Flags
         run: npm run content:test-flags
 
+      - name: Smoke Test Site URL Wiring
+        run: npm run content:test-site-url
+
       - name: Typecheck Content Scripts
         run: npm run content:typecheck
 

--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ Optional options:
 - `--force`: generate a same-day variant if today's slug already exists
 - `--lang=en|ja|ar`: generate only one language variant
 - `TOPIC_HINT="your angle"`: guide the editorial angle for that day
+- `TREND_MIN_SOURCES=2`: temporarily lower required source count (default: `3`)
 
 Validate config/schema only (no feed fetch, no generation):
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "content:daily": "node --import tsx --env-file-if-exists=.env.local scripts/generate-daily-ai-trend-posts.ts",
     "content:check": "node --import tsx --env-file-if-exists=.env.local scripts/generate-daily-ai-trend-posts.ts --dry-run --validate-config --lang=en",
     "content:test-flags": "node --test scripts/tests/content-flags.test.mjs",
+    "content:test-site-url": "node --import tsx --test scripts/tests/site-url-smoke.test.mjs",
     "content:typecheck": "tsc -p tsconfig.scripts.json --noEmit",
     "content:daily:pr": "bash scripts/local-daily-content-pr.sh",
     "content:daily:install-launchd": "bash scripts/install-launchd-daily-content.sh",

--- a/scripts/generate-daily-ai-trend-posts.ts
+++ b/scripts/generate-daily-ai-trend-posts.ts
@@ -18,10 +18,12 @@ import {
   POSTS_DIR,
   COVER_IMAGE,
   AUTHOR_NAME,
+  TOPIC_HINT,
   initializeConfigs,
   ConfigState,
 } from "./lib/config";
 import { fetchFeed } from "./lib/feed";
+import type { FeedItem } from "./lib/feed";
 import { AiState } from "./lib/ai";
 import { flushMetrics } from "./lib/metrics";
 import { createStagedArticle } from "./lib/article-builder";
@@ -89,8 +91,87 @@ const guardApiKey = () => {
   return !((isOfficialOpenAi && !API_KEY) && (console.log("OPENAI_API_KEY is not set for official OpenAI endpoint; skipping daily trend draft generation."), process.exit(0)));
 };
 
+const MIN_SOURCES_REQUIRED = Number.parseInt(process.env.TREND_MIN_SOURCES ?? "3", 10);
+
 const guardMinSources = (sources) => {
-  return sources.length < 3 ? (console.log("Low sources, skip"), process.exit(0)) : sources;
+  return sources.length < Math.max(1, MIN_SOURCES_REQUIRED)
+    ? (console.log("Low sources, skip"), process.exit(0))
+    : sources;
+};
+
+type RankedSource = {
+  title: string;
+  url: string;
+  source: string;
+  summary?: string;
+};
+
+const toRankedSource = (source: FeedItem): RankedSource => ({
+  title: source.title,
+  url: source.link,
+  source: source.feed,
+  summary: source.description,
+});
+
+const uniqueByUrl = (sources: RankedSource[]) =>
+  Array.from(new Map(sources.map((item) => [item.url, item])).values());
+
+const normalizeWord = (value: string) => value.trim().toLowerCase();
+
+const topicHintTerms = TOPIC_HINT
+  .split(/[\s,]+/)
+  .map(normalizeWord)
+  .filter((term) => term.length >= 3);
+
+const allConfiguredKeywords = Object.values(ConfigState.KEYWORDS)
+  .flat()
+  .map(normalizeWord);
+
+const includesAnyKeyword = (text: string, keywords: string[]) =>
+  keywords.some((keyword) => text.includes(keyword));
+
+const pickRankedSources = (rawSources: FeedItem[]): RankedSource[] => {
+  const normalized = rawSources.map(toRankedSource);
+  const trendKeywords = ConfigState.KEYWORDS.trend.map(normalizeWord);
+
+  const byTrend = uniqueByUrl(
+    normalized.filter((item) =>
+      includesAnyKeyword(
+        `${item.title} ${item.summary ?? ""}`.toLowerCase(),
+        trendKeywords
+      )
+    )
+  );
+  console.log(`[daily-trends] source pool: raw=${normalized.length}, trend=${byTrend.length}`);
+  if (byTrend.length >= MIN_SOURCES_REQUIRED) {
+    return byTrend.slice(0, 6);
+  }
+
+  const expandedKeywords = Array.from(
+    new Set([...allConfiguredKeywords, ...topicHintTerms])
+  );
+  const byExpanded = uniqueByUrl(
+    normalized.filter((item) =>
+      includesAnyKeyword(
+        `${item.title} ${item.summary ?? ""}`.toLowerCase(),
+        expandedKeywords
+      )
+    )
+  );
+  console.log(`[daily-trends] source pool: expanded=${byExpanded.length}`);
+  if (byExpanded.length >= MIN_SOURCES_REQUIRED) {
+    console.warn("[daily-trends] trend-only sources were low; using expanded keyword matching.");
+    return byExpanded.slice(0, 6);
+  }
+
+  const fallbackPool = uniqueByUrl(normalized);
+  console.log(`[daily-trends] source pool: fallback=${fallbackPool.length}, min_required=${Math.max(1, MIN_SOURCES_REQUIRED)}`);
+  if (fallbackPool.length >= MIN_SOURCES_REQUIRED) {
+    console.warn("[daily-trends] keyword-matched sources were low; using top feed items fallback.");
+    return fallbackPool.slice(0, 6);
+  }
+
+  return fallbackPool;
 };
 
 const parseLangFlag = () => {
@@ -130,12 +211,7 @@ async function main() {
     .filter(r => r.status === "fulfilled")
     .flatMap(r => r.value);
 
-  const ranked = guardMinSources(
-    rawSources
-      .filter(s => ConfigState.KEYWORDS.trend.some(k => s.title.toLowerCase().includes(k)))
-      .slice(0, 6)
-      .map(s => ({ title: s.title, url: s.link, source: s.feed, summary: s.description }))
-  );
+  const ranked = guardMinSources(pickRankedSources(rawSources));
 
   const content = await createStagedArticle({
     dateString,

--- a/scripts/tests/site-url-smoke.test.mjs
+++ b/scripts/tests/site-url-smoke.test.mjs
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+const loadModule = async (path) => import(path);
+const pickExport = (mod, key) => mod[key] ?? mod.default?.[key];
+const pickDefaultFn = (mod) => mod.default ?? mod;
+
+test("site config exposes canonical url and origins", () => {
+  return loadModule("../../src/lib/site-config.ts").then((mod) => {
+    const SITE_URL = pickExport(mod, "SITE_URL");
+    const SITE_ORIGINS = pickExport(mod, "SITE_ORIGINS");
+
+    assert.equal(typeof SITE_URL, "string");
+    assert.ok(SITE_URL.startsWith("http"));
+    assert.ok(Array.isArray(SITE_ORIGINS));
+    assert.ok(SITE_ORIGINS.includes(SITE_URL));
+    assert.ok(SITE_ORIGINS.every((origin) => origin.startsWith("http")));
+  });
+});
+
+test("robots uses SITE_URL-based sitemap entries", async () => {
+  const [robotsMod, siteConfigMod] = await Promise.all([
+    loadModule("../../src/app/robots.ts"),
+    loadModule("../../src/lib/site-config.ts"),
+  ]);
+  const robots = pickDefaultFn(robotsMod);
+  const SITE_URL = pickExport(siteConfigMod, "SITE_URL");
+
+  const data = robots();
+  const sitemapUrls = Array.isArray(data.sitemap) ? data.sitemap : [];
+
+  assert.ok(sitemapUrls.includes(`${SITE_URL}/sitemap.xml`));
+  assert.ok(sitemapUrls.includes(`${SITE_URL}/image-sitemap.xml`));
+});
+
+test("sitemap root entries are anchored to SITE_URL", async () => {
+  const [sitemapMod, siteConfigMod] = await Promise.all([
+    loadModule("../../src/app/sitemap.ts"),
+    loadModule("../../src/lib/site-config.ts"),
+  ]);
+  const sitemap = pickDefaultFn(sitemapMod);
+  const SITE_URL = pickExport(siteConfigMod, "SITE_URL");
+
+  const entries = await sitemap();
+  const urls = entries.map((entry) => entry.url);
+
+  assert.ok(urls.includes(SITE_URL));
+  assert.ok(urls.includes(`${SITE_URL}/blog`));
+  assert.ok(urls.every((url) => url.startsWith(SITE_URL)));
+});

--- a/src/lib/site-config.ts
+++ b/src/lib/site-config.ts
@@ -1,5 +1,12 @@
 const DEFAULT_SITE_URL = "https://www.neowhisper.net";
 
+/**
+ * Site-level URL config only.
+ *
+ * Keep this module narrowly scoped to canonical site URL/origin resolution.
+ * Do NOT add unrelated app settings, feature flags, or content constants here.
+ * Create dedicated modules for those concerns to avoid a "god config" file.
+ */
 export const SITE_URL = (process.env.NEXT_PUBLIC_SITE_URL ?? DEFAULT_SITE_URL)
   .replace(/\/+$/, "");
 


### PR DESCRIPTION
## Summary

This follow-up PR completes the remaining post-merge tasks and improves daily source selection behavior when feeds are sparse.

## Changes

1. Added site URL smoke tests
- New test file: `scripts/tests/site-url-smoke.test.mjs`
- Verifies:
  - `SITE_URL` / `SITE_ORIGINS` shape
  - `robots.ts` sitemap URLs are derived from `SITE_URL`
  - `sitemap.ts` root entries are anchored to `SITE_URL`

2. Added a CI step for the site URL smoke tests
- `.github/workflows/ci.yml`
- New step runs `npm run content:test-site-url`

3. Added guardrail comment block to `src/lib/site-config.ts`
- Clarifies scope and prevents `site-config.ts` from becoming a generic dump config.

4. Improved daily source selection diagnostics + fallback behavior
- `scripts/generate-daily-ai-trend-posts.ts`
- Adds clear source pool logs:
  - raw count
  - trend keyword match count
  - expanded keyword match count
  - fallback pool count
- Introduces configurable minimum source threshold via env:
  - `TREND_MIN_SOURCES` (default `3`)
- Selection now attempts:
  1) trend keywords
  2) expanded keyword set (all configured keywords + `TOPIC_HINT` terms)
  3) top feed items fallback
- If all pools are below threshold, it still safely skips.

5. README update
- Documents `TREND_MIN_SOURCES` in manual options.

## Validation

- `npm run content:typecheck`
- `npm run content:check`
- `npm run content:test-flags`
- `npm run content:test-site-url`
- `npm run build`
- `npm run content:daily -- --dry-run --lang=en`
- `TREND_MIN_SOURCES=1 npm run content:daily -- --dry-run --lang=en`

## Notes

- In the current environment, feed fetch produced `raw=0`, so generation still skipped (`Low sources, skip`).
- This is feed/source availability related, not model-quality related.
