### PR TITLE
feat(content): category-driven recent-news 3-language post workflow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "@semantic-release/npm": "^13.1.5",
         "@semantic-release/release-notes-generator": "^14.1.0",
         "@tailwindcss/postcss": "^4",
+        "@types/he": "^1.2.3",
         "@types/jest": "^30.0.0",
         "@types/mdx": "^2.0.13",
         "@types/node": "^25",
@@ -4670,6 +4671,13 @@
       "dependencies": {
         "@types/unist": "*"
       }
+    },
+    "node_modules/@types/he": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@types/he/-/he-1.2.3.tgz",
+      "integrity": "sha512-q67/qwlxblDzEDvzHhVkwc1gzVWxaNxeyHUBF4xElrvjL11O+Ytze+1fGpBHlr/H9myiBUaUXNnNPmBHxxfAcA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "content:test-safety": "node --import tsx --test scripts/tests/content-safety.test.mjs",
     "content:test-site-url": "node --import tsx --test scripts/tests/site-url-smoke.test.mjs",
     "content:typecheck": "tsc -p tsconfig.scripts.json --noEmit",
+    "content:list-categories": "node --import tsx scripts/list-categories-with-counts.ts",
     "content:daily:pr": "bash scripts/local-daily-content-pr.sh",
     "content:daily:install-launchd": "bash scripts/install-launchd-daily-content.sh",
     "content:sync-main": "bash scripts/sync-local-main.sh",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@semantic-release/npm": "^13.1.5",
     "@semantic-release/release-notes-generator": "^14.1.0",
     "@tailwindcss/postcss": "^4",
+    "@types/he": "^1.2.3",
     "@types/jest": "^30.0.0",
     "@types/mdx": "^2.0.13",
     "@types/node": "^25",

--- a/scripts/config/categories.ts
+++ b/scripts/config/categories.ts
@@ -171,6 +171,86 @@ export const categories: CategoryConfig[] = [
     ]
   },
   {
+    "slug": "mobile-development",
+    "nameEn": "Mobile Development",
+    "nameJa": "モバイル開発",
+    "nameAr": "تطوير تطبيقات الجوال",
+    "keywords": [
+      "ios",
+      "android",
+      "swift",
+      "kotlin",
+      "react native",
+      "flutter",
+      "mobile app",
+      "app store",
+      "play store"
+    ]
+  },
+  {
+    "slug": "ai-policy-governance",
+    "nameEn": "AI Policy & Governance",
+    "nameJa": "AIポリシー・ガバナンス",
+    "nameAr": "سياسات وحوكمة الذكاء الاصطناعي",
+    "keywords": [
+      "policy",
+      "regulation",
+      "governance",
+      "compliance",
+      "risk",
+      "safety",
+      "privacy",
+      "audit"
+    ]
+  },
+  {
+    "slug": "hardware-edge",
+    "nameEn": "Hardware & Edge AI",
+    "nameJa": "ハードウェア・エッジAI",
+    "nameAr": "العتاد والذكاء الاصطناعي على الحافة",
+    "keywords": [
+      "chip",
+      "gpu",
+      "npu",
+      "edge",
+      "embedded",
+      "on-device",
+      "accelerator",
+      "inference hardware"
+    ]
+  },
+  {
+    "slug": "data-science-analytics",
+    "nameEn": "Data Science & Analytics",
+    "nameJa": "データサイエンス・分析",
+    "nameAr": "علم البيانات والتحليلات",
+    "keywords": [
+      "analytics",
+      "data science",
+      "notebook",
+      "feature engineering",
+      "forecasting",
+      "classification",
+      "clustering",
+      "bi"
+    ]
+  },
+  {
+    "slug": "open-source",
+    "nameEn": "Open Source",
+    "nameJa": "オープンソース",
+    "nameAr": "المصدر المفتوح",
+    "keywords": [
+      "open source",
+      "github",
+      "maintainer",
+      "community",
+      "license",
+      "repository",
+      "release notes"
+    ]
+  },
+  {
     "slug": "tech-tips",
     "nameEn": "Tech Tips",
     "nameJa": "Tech Tips",

--- a/scripts/generate-daily-ai-trend-posts.ts
+++ b/scripts/generate-daily-ai-trend-posts.ts
@@ -35,10 +35,14 @@ import {
 import contentSafety from "./lib/content-safety";
 import { resolveCategoryByInput } from "./lib/utils";
 
-const { normalizeExcerptText, normalizeMetadataText, sanitizeGeneratedMarkdown } = contentSafety;
+const {
+  normalizeExcerptText,
+  normalizeMetadataText,
+  sanitizeGeneratedMarkdown,
+} = contentSafety;
 
 const TocConfigSchema = z.object({
-  excludedHeadings: z.array(z.string())
+  excludedHeadings: z.array(z.string()),
 });
 
 type TocConfig = z.infer<typeof TocConfigSchema>;
@@ -72,8 +76,8 @@ const headingToAnchor = (text: string): string =>
     .replace(/-+/g, "-")
     .replace(/^-|-$/g, "");
 
-const createShouldExcludeHeading = (excludedHeadings: string[]) =>
-  (text: string) =>
+const createShouldExcludeHeading =
+  (excludedHeadings: string[]) => (text: string) =>
     excludedHeadings.some((excluded) => text.toLowerCase().includes(excluded));
 
 const createGenerateToc = (excludedHeadings: string[]) => {
@@ -81,15 +85,15 @@ const createGenerateToc = (excludedHeadings: string[]) => {
   return (markdownBody: string, tocHeading: string): string => {
     const headings = [...markdownBody.matchAll(/^##\s+(.+)$/gm)]
       .map((match: RegExpMatchArray) => (match[1] ?? "").trim())
-      .filter(text => !shouldExclude(text))
-      .map(text => ({
+      .filter((text) => !shouldExclude(text))
+      .map((text) => ({
         text,
-        anchor: headingToAnchor(text)
+        anchor: headingToAnchor(text),
       }));
 
     return headings.length === 0
       ? ""
-      : `${tocHeading}\n\n${headings.map(h => `- [${h.text}](#${h.anchor})`).join("\n")}\n\n---\n\n`;
+      : `${tocHeading}\n\n${headings.map((h) => `- [${h.text}](#${h.anchor})`).join("\n")}\n\n---\n\n`;
   };
 };
 
@@ -100,7 +104,12 @@ type FrontmatterInput = {
   dateString: string;
 };
 
-const buildFrontmatter = ({ title, excerpt, categoryName, dateString }: FrontmatterInput): string[] => [
+const buildFrontmatter = ({
+  title,
+  excerpt,
+  categoryName,
+  dateString,
+}: FrontmatterInput): string[] => [
   "---",
   `title: "${yamlString(title)}"`,
   `date: "${dateString}"`,
@@ -115,7 +124,7 @@ const buildFrontmatter = ({ title, excerpt, categoryName, dateString }: Frontmat
 
 const getCategoryDisplayName = (
   category: CategoryDefinition,
-  lang: LanguageCode
+  lang: LanguageCode,
 ): string => {
   const keyByLang: Record<LanguageCode, keyof CategoryDefinition> = {
     en: "nameEn",
@@ -128,15 +137,30 @@ const getCategoryDisplayName = (
 const writePostFile = async (filePath: string, doc: string): Promise<void> =>
   DRY_RUN
     ? void console.log(`[DRY RUN] ${filePath}`)
-    : fs.writeFile(filePath, doc).then(() => console.log(`[daily-trends] wrote ${filePath}`));
+    : fs
+        .writeFile(filePath, doc)
+        .then(() => console.log(`[daily-trends] wrote ${filePath}`));
 
 const guardApiKey = () => {
   const isOfficialOpenAi = new URL(API_BASE_URL).hostname === "api.openai.com";
-  return !((isOfficialOpenAi && !API_KEY) && (console.log("OPENAI_API_KEY is not set for official OpenAI endpoint; skipping daily trend draft generation."), process.exit(0)));
+  return !(
+    isOfficialOpenAi &&
+    !API_KEY &&
+    (console.log(
+      "OPENAI_API_KEY is not set for official OpenAI endpoint; skipping daily trend draft generation.",
+    ),
+    process.exit(0))
+  );
 };
 
-const MIN_SOURCES_REQUIRED = Number.parseInt(process.env.TREND_MIN_SOURCES ?? "3", 10);
-const DEFAULT_RECENT_DAYS = Number.parseInt(process.env.TREND_RECENT_DAYS ?? "3", 10);
+const MIN_SOURCES_REQUIRED = Number.parseInt(
+  process.env.TREND_MIN_SOURCES ?? "3",
+  10,
+);
+const DEFAULT_RECENT_DAYS = Number.parseInt(
+  process.env.TREND_RECENT_DAYS ?? "3",
+  10,
+);
 
 const guardMinSources = (sources: RankedSource[]): RankedSource[] => {
   return sources.length < Math.max(1, MIN_SOURCES_REQUIRED)
@@ -165,8 +189,7 @@ const uniqueByUrl = (sources: RankedSource[]) =>
 
 const normalizeWord = (value: string) => value.trim().toLowerCase();
 
-const topicHintTerms = TOPIC_HINT
-  .split(/[\s,]+/)
+const topicHintTerms = TOPIC_HINT.split(/[\s,]+/)
   .map(normalizeWord)
   .filter((term) => term.length >= 3);
 
@@ -185,61 +208,80 @@ const pickRankedSources = (rawSources: FeedItem[]): RankedSource[] => {
     normalized.filter((item) =>
       includesAnyKeyword(
         `${item.title} ${item.summary ?? ""}`.toLowerCase(),
-        trendKeywords
-      )
-    )
+        trendKeywords,
+      ),
+    ),
   );
-  console.log(`[daily-trends] source pool: raw=${normalized.length}, trend=${byTrend.length}`);
+  console.log(
+    `[daily-trends] source pool: raw=${normalized.length}, trend=${byTrend.length}`,
+  );
   if (byTrend.length >= MIN_SOURCES_REQUIRED) {
     return byTrend.slice(0, 6);
   }
 
   const expandedKeywords = Array.from(
-    new Set([...allConfiguredKeywords, ...topicHintTerms])
+    new Set([...allConfiguredKeywords, ...topicHintTerms]),
   );
   const byExpanded = uniqueByUrl(
     normalized.filter((item) =>
       includesAnyKeyword(
         `${item.title} ${item.summary ?? ""}`.toLowerCase(),
-        expandedKeywords
-      )
-    )
+        expandedKeywords,
+      ),
+    ),
   );
   console.log(`[daily-trends] source pool: expanded=${byExpanded.length}`);
   if (byExpanded.length >= MIN_SOURCES_REQUIRED) {
-    console.warn("[daily-trends] trend-only sources were low; using expanded keyword matching.");
+    console.warn(
+      "[daily-trends] trend-only sources were low; using expanded keyword matching.",
+    );
     return byExpanded.slice(0, 6);
   }
 
   const fallbackPool = uniqueByUrl(normalized);
-  console.log(`[daily-trends] source pool: fallback=${fallbackPool.length}, min_required=${Math.max(1, MIN_SOURCES_REQUIRED)}`);
+  console.log(
+    `[daily-trends] source pool: fallback=${fallbackPool.length}, min_required=${Math.max(1, MIN_SOURCES_REQUIRED)}`,
+  );
   if (fallbackPool.length >= MIN_SOURCES_REQUIRED) {
-    console.warn("[daily-trends] keyword-matched sources were low; using top feed items fallback.");
+    console.warn(
+      "[daily-trends] keyword-matched sources were low; using top feed items fallback.",
+    );
     return fallbackPool.slice(0, 6);
   }
 
   return fallbackPool;
 };
 
-const parsePositiveInt = (value: string | undefined, fallback: number): number => {
+const parsePositiveInt = (
+  value: string | undefined,
+  fallback: number,
+): number => {
   const parsed = Number.parseInt(value ?? "", 10);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
 };
 
 const parseCategoryFlag = (): string | null => {
-  const arg = process.argv.find((entry) => entry.startsWith("--category="));
+  const arg = process.argv.find((entry: string) =>
+    entry.startsWith("--category="),
+  );
   if (!arg) return null;
   const raw = arg.slice("--category=".length).trim();
   return raw.length > 0 ? raw : null;
 };
 
 const parseRecentDays = (): number => {
-  const arg = process.argv.find((entry) => entry.startsWith("--recent-days="));
+  const arg = process.argv.find((entry: string) =>
+    entry.startsWith("--recent-days="),
+  );
   const value = arg?.slice("--recent-days=".length);
   return parsePositiveInt(value, DEFAULT_RECENT_DAYS);
 };
 
-const isRecentSource = (source: RankedSource, recentDays: number, nowMs: number): boolean => {
+const isRecentSource = (
+  source: RankedSource,
+  recentDays: number,
+  nowMs: number,
+): boolean => {
   if (!source.publishedAt) return false;
   const publishedMs = new Date(source.publishedAt).getTime();
   if (Number.isNaN(publishedMs)) return false;
@@ -250,21 +292,25 @@ const isRecentSource = (source: RankedSource, recentDays: number, nowMs: number)
 const pickSourcesByCategoryAndRecency = (
   sources: RankedSource[],
   categoryKeywords: string[],
-  recentDays: number
+  recentDays: number,
 ): RankedSource[] => {
   const nowMs = Date.now();
-  const normalizedKeywords = categoryKeywords.map((keyword) => keyword.toLowerCase());
+  const normalizedKeywords = categoryKeywords.map((keyword) =>
+    keyword.toLowerCase(),
+  );
   const withSignals = sources.map((source) => {
     const text = `${source.title} ${source.summary ?? ""}`.toLowerCase();
     const keywordHits = normalizedKeywords.reduce(
       (sum, keyword) => sum + (text.includes(keyword) ? 1 : 0),
-      0
+      0,
     );
     const recent = isRecentSource(source, recentDays, nowMs);
     return { source, keywordHits, recent };
   });
 
-  const strictMatches = withSignals.filter((item) => item.recent && item.keywordHits > 0);
+  const strictMatches = withSignals.filter(
+    (item) => item.recent && item.keywordHits > 0,
+  );
   if (strictMatches.length >= Math.max(1, MIN_SOURCES_REQUIRED)) {
     return strictMatches
       .sort((a, b) => b.keywordHits - a.keywordHits)
@@ -295,20 +341,24 @@ const isLanguageCode = (value: string): value is LanguageCode =>
   (LANGUAGE_ORDER as readonly string[]).includes(value);
 
 const parseLangFlag = (): LanguageCode | null => {
-  const arg = process.argv.find((entry) => entry.startsWith("--lang="));
+  const arg = process.argv.find((entry: string) => entry.startsWith("--lang="));
   if (!arg) return null;
   const normalized = arg.slice("--lang=".length).trim().toLowerCase();
   return isLanguageCode(normalized) ? normalized : null;
 };
 
 const resolveTargetLanguages = (): LanguageCode[] => {
-  const explicitArg = process.argv.find((entry) => entry.startsWith("--lang="));
+  const explicitArg = process.argv.find((entry: string) =>
+    entry.startsWith("--lang="),
+  );
   const selectedLang = parseLangFlag();
 
   if (!explicitArg) return [...LANGUAGE_ORDER];
   if (!selectedLang) {
     const badValue = explicitArg.slice("--lang=".length).trim();
-    throw new Error(`Unsupported --lang value "${badValue}". Use one of: ${LANGUAGE_ORDER.join(", ")}`);
+    throw new Error(
+      `Unsupported --lang value "${badValue}". Use one of: ${LANGUAGE_ORDER.join(", ")}`,
+    );
   }
   return [selectedLang];
 };
@@ -330,45 +380,61 @@ async function main() {
 
   if (requestedCategoryInput && !requestedCategory) {
     throw new Error(
-      `Unsupported --category value "${requestedCategoryInput}". Use one of configured category slugs/names.`
+      `Unsupported --category value "${requestedCategoryInput}". Use one of configured category slugs/names.`,
     );
   }
 
   if (VALIDATE_CONFIG_ONLY) {
-    console.log(`[daily-trends] config validation OK (languages: ${targetLanguages.join(", ")})`);
+    console.log(
+      `[daily-trends] config validation OK (languages: ${targetLanguages.join(", ")})`,
+    );
     return;
   }
 
   const dateString = new Date().toISOString().slice(0, 10);
   console.log(`[daily-trends] starting ${dateString}`);
 
-  const rawSources = (await Promise.allSettled(ConfigState.FEEDS.map(f => fetchFeed(f))))
-    .filter((r): r is PromiseFulfilledResult<FeedItem[]> => r.status === "fulfilled")
-    .flatMap(r => r.value);
+  const rawSources = (
+    await Promise.allSettled(ConfigState.FEEDS.map((f) => fetchFeed(f)))
+  )
+    .filter(
+      (r): r is PromiseFulfilledResult<FeedItem[]> => r.status === "fulfilled",
+    )
+    .flatMap((r) => r.value);
 
   const baseRanked = pickRankedSources(rawSources);
   const ranked = guardMinSources(
     requestedCategory
-      ? pickSourcesByCategoryAndRecency(baseRanked, requestedCategory.keywords, recentDays)
-      : baseRanked
+      ? pickSourcesByCategoryAndRecency(
+          baseRanked,
+          requestedCategory.keywords,
+          recentDays,
+        )
+      : baseRanked,
   );
 
   if (requestedCategory) {
     console.log(
-      `[daily-trends] selected category=${requestedCategory.slug}, recent_days=${recentDays}, sources=${ranked.length}`
+      `[daily-trends] selected category=${requestedCategory.slug}, recent_days=${recentDays}, sources=${ranked.length}`,
     );
   }
 
-  const content = await createStagedArticle({
+  const content = (await createStagedArticle({
     dateString,
     sources: ranked,
     targetLanguages,
     preferredCategorySlug: requestedCategory?.slug ?? null,
-  }) as StagedArticle;
-  const category = ConfigState.CATEGORY_MAP.get(content.categorySlug)
-    ?? (ConfigState.CATEGORY_DEFINITIONS[0] as CategoryDefinition);
+  })) as StagedArticle;
+  const category =
+    ConfigState.CATEGORY_MAP.get(content.categorySlug) ??
+    (ConfigState.CATEGORY_DEFINITIONS[0] as CategoryDefinition);
 
-  void (!ConfigState.CATEGORY_MAP.has(content.categorySlug) && console.warn(`[daily-trends] Category slug "${content.categorySlug}" not found — falling back to "${category.slug}".`));
+  void (
+    !ConfigState.CATEGORY_MAP.has(content.categorySlug) &&
+    console.warn(
+      `[daily-trends] Category slug "${content.categorySlug}" not found — falling back to "${category.slug}".`,
+    )
+  );
 
   const baseSlug = `ai-it-trend-brief-${dateString}-${content.slugSuffix.toLowerCase().replace(/[^a-z0-9]+/g, "-")}`;
   await Promise.all(
@@ -376,42 +442,53 @@ async function main() {
       const meta = LANGUAGE_LABELS[lang];
       const localized = content[lang] as LocalizedContent;
       const finalBody = sanitizeGeneratedMarkdown(
-        Object.values(localized.sections).join("\n\n")
+        Object.values(localized.sections).join("\n\n"),
       );
       const toc = generateToc(finalBody, meta.tocHeading);
-      const fallbackTitle = normalizeMetadataText(content.en.title, "Daily AI Trend Brief");
-      const title = normalizeMetadataText(
-        localized.title,
-        fallbackTitle
+      const fallbackTitle = normalizeMetadataText(
+        content.en.title,
+        "Daily AI Trend Brief",
       );
-      const excerptFallback = finalBody.split("\n").find((line) => line.trim() && !line.startsWith("#"))?.trim() ?? "";
+      const title = normalizeMetadataText(localized.title, fallbackTitle);
+      const excerptFallback =
+        finalBody
+          .split("\n")
+          .find((line) => line.trim() && !line.startsWith("#"))
+          ?.trim() ?? "";
       const excerpt = normalizeExcerptText(localized.excerpt, excerptFallback);
       const referencesSection = ranked
         .map((s) => `- [${sanitizeGeneratedMarkdown(s.title)}](${s.url})`)
         .join("\n");
 
-      const doc = sanitizeGeneratedMarkdown([
-        ...buildFrontmatter({
-          title,
-          excerpt,
-          categoryName: getCategoryDisplayName(category, lang),
-          dateString
-        }),
-        "",
-        toc,
-        finalBody,
-        "",
-        meta.referencesHeading,
-        "",
-        referencesSection
-      ].join("\n"));
+      const doc = sanitizeGeneratedMarkdown(
+        [
+          ...buildFrontmatter({
+            title,
+            excerpt,
+            categoryName: getCategoryDisplayName(category, lang),
+            dateString,
+          }),
+          "",
+          toc,
+          finalBody,
+          "",
+          meta.referencesHeading,
+          "",
+          referencesSection,
+        ].join("\n"),
+      );
 
-      const filePath = path.join(POSTS_DIR, `${baseSlug}${meta.fileSuffix}.mdx`);
+      const filePath = path.join(
+        POSTS_DIR,
+        `${baseSlug}${meta.fileSuffix}.mdx`,
+      );
       await writePostFile(filePath, doc);
-    })
+    }),
   );
 
-  console.log(`[RUN COMPLETE] Total tokens used: ${AiState.totalTokensUsed} | Sections generated: ${Object.keys(content.en.sections).length}/${content.sections.length} | Languages: ${targetLanguages.join("/")}`);
+  console.log(
+    `[RUN COMPLETE] Total tokens used: ${AiState.totalTokensUsed} | Sections generated: ${Object.keys(content.en.sections).length}/${content.sections.length} | Languages: ${targetLanguages.join("/")}`,
+  );
 
   await flushMetrics();
 }

--- a/scripts/generate-daily-ai-trend-posts.ts
+++ b/scripts/generate-daily-ai-trend-posts.ts
@@ -33,6 +33,7 @@ import {
   type LanguageCode,
 } from "./lib/constants";
 import contentSafety from "./lib/content-safety";
+import { resolveCategoryByInput } from "./lib/utils";
 
 const { normalizeExcerptText, normalizeMetadataText, sanitizeGeneratedMarkdown } = contentSafety;
 
@@ -135,6 +136,7 @@ const guardApiKey = () => {
 };
 
 const MIN_SOURCES_REQUIRED = Number.parseInt(process.env.TREND_MIN_SOURCES ?? "3", 10);
+const DEFAULT_RECENT_DAYS = Number.parseInt(process.env.TREND_RECENT_DAYS ?? "3", 10);
 
 const guardMinSources = (sources: RankedSource[]): RankedSource[] => {
   return sources.length < Math.max(1, MIN_SOURCES_REQUIRED)
@@ -147,6 +149,7 @@ type RankedSource = {
   url: string;
   source: string;
   summary?: string;
+  publishedAt?: string;
 };
 
 const toRankedSource = (source: FeedItem): RankedSource => ({
@@ -154,6 +157,7 @@ const toRankedSource = (source: FeedItem): RankedSource => ({
   url: source.link,
   source: source.feed,
   summary: source.description,
+  publishedAt: source.publishedAt,
 });
 
 const uniqueByUrl = (sources: RankedSource[]) =>
@@ -217,6 +221,76 @@ const pickRankedSources = (rawSources: FeedItem[]): RankedSource[] => {
   return fallbackPool;
 };
 
+const parsePositiveInt = (value: string | undefined, fallback: number): number => {
+  const parsed = Number.parseInt(value ?? "", 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+};
+
+const parseCategoryFlag = (): string | null => {
+  const arg = process.argv.find((entry) => entry.startsWith("--category="));
+  if (!arg) return null;
+  const raw = arg.slice("--category=".length).trim();
+  return raw.length > 0 ? raw : null;
+};
+
+const parseRecentDays = (): number => {
+  const arg = process.argv.find((entry) => entry.startsWith("--recent-days="));
+  const value = arg?.slice("--recent-days=".length);
+  return parsePositiveInt(value, DEFAULT_RECENT_DAYS);
+};
+
+const isRecentSource = (source: RankedSource, recentDays: number, nowMs: number): boolean => {
+  if (!source.publishedAt) return false;
+  const publishedMs = new Date(source.publishedAt).getTime();
+  if (Number.isNaN(publishedMs)) return false;
+  const cutoffMs = nowMs - recentDays * 24 * 60 * 60 * 1000;
+  return publishedMs >= cutoffMs;
+};
+
+const pickSourcesByCategoryAndRecency = (
+  sources: RankedSource[],
+  categoryKeywords: string[],
+  recentDays: number
+): RankedSource[] => {
+  const nowMs = Date.now();
+  const normalizedKeywords = categoryKeywords.map((keyword) => keyword.toLowerCase());
+  const withSignals = sources.map((source) => {
+    const text = `${source.title} ${source.summary ?? ""}`.toLowerCase();
+    const keywordHits = normalizedKeywords.reduce(
+      (sum, keyword) => sum + (text.includes(keyword) ? 1 : 0),
+      0
+    );
+    const recent = isRecentSource(source, recentDays, nowMs);
+    return { source, keywordHits, recent };
+  });
+
+  const strictMatches = withSignals.filter((item) => item.recent && item.keywordHits > 0);
+  if (strictMatches.length >= Math.max(1, MIN_SOURCES_REQUIRED)) {
+    return strictMatches
+      .sort((a, b) => b.keywordHits - a.keywordHits)
+      .map((item) => item.source)
+      .slice(0, 6);
+  }
+
+  const recentOnly = withSignals.filter((item) => item.recent);
+  if (recentOnly.length >= Math.max(1, MIN_SOURCES_REQUIRED)) {
+    return recentOnly
+      .sort((a, b) => b.keywordHits - a.keywordHits)
+      .map((item) => item.source)
+      .slice(0, 6);
+  }
+
+  const keywordOnly = withSignals.filter((item) => item.keywordHits > 0);
+  if (keywordOnly.length >= Math.max(1, MIN_SOURCES_REQUIRED)) {
+    return keywordOnly
+      .sort((a, b) => b.keywordHits - a.keywordHits)
+      .map((item) => item.source)
+      .slice(0, 6);
+  }
+
+  return sources.slice(0, 6);
+};
+
 const isLanguageCode = (value: string): value is LanguageCode =>
   (LANGUAGE_ORDER as readonly string[]).includes(value);
 
@@ -246,8 +320,19 @@ async function main() {
   await initializeConfigs();
 
   const targetLanguages = resolveTargetLanguages();
+  const requestedCategoryInput = parseCategoryFlag();
+  const recentDays = parseRecentDays();
   const resolvedTocConfig = loadTocConfig();
   const generateToc = createGenerateToc(resolvedTocConfig.excludedHeadings);
+  const requestedCategory = requestedCategoryInput
+    ? resolveCategoryByInput(requestedCategoryInput)
+    : null;
+
+  if (requestedCategoryInput && !requestedCategory) {
+    throw new Error(
+      `Unsupported --category value "${requestedCategoryInput}". Use one of configured category slugs/names.`
+    );
+  }
 
   if (VALIDATE_CONFIG_ONLY) {
     console.log(`[daily-trends] config validation OK (languages: ${targetLanguages.join(", ")})`);
@@ -261,12 +346,24 @@ async function main() {
     .filter((r): r is PromiseFulfilledResult<FeedItem[]> => r.status === "fulfilled")
     .flatMap(r => r.value);
 
-  const ranked = guardMinSources(pickRankedSources(rawSources));
+  const baseRanked = pickRankedSources(rawSources);
+  const ranked = guardMinSources(
+    requestedCategory
+      ? pickSourcesByCategoryAndRecency(baseRanked, requestedCategory.keywords, recentDays)
+      : baseRanked
+  );
+
+  if (requestedCategory) {
+    console.log(
+      `[daily-trends] selected category=${requestedCategory.slug}, recent_days=${recentDays}, sources=${ranked.length}`
+    );
+  }
 
   const content = await createStagedArticle({
     dateString,
     sources: ranked,
-    targetLanguages
+    targetLanguages,
+    preferredCategorySlug: requestedCategory?.slug ?? null,
   }) as StagedArticle;
   const category = ConfigState.CATEGORY_MAP.get(content.categorySlug)
     ?? (ConfigState.CATEGORY_DEFINITIONS[0] as CategoryDefinition);

--- a/scripts/lib/article-builder.ts
+++ b/scripts/lib/article-builder.ts
@@ -1,6 +1,7 @@
 import process from "node:process";
 import { callAi, parseJsonWithRepair, AiState } from "./ai";
 import { startStage, endStage } from "./metrics";
+import { ConfigState } from "./config";
 import {
   SYSTEM_RULES,
   CONTENT_CONSTRAINTS,
@@ -8,9 +9,14 @@ import {
   LANGUAGE_ORDER,
   MIN_WORDS_THRESHOLD,
   EXPANSION_RETRY_LIMIT,
-  type LanguageCode
+  type LanguageCode,
 } from "./constants";
-import { pickCategory, computeWordCounts, selectSectionsToExpand, polishMetadata } from "./utils";
+import {
+  pickCategory,
+  computeWordCounts,
+  selectSectionsToExpand,
+  polishMetadata,
+} from "./utils";
 
 type SourceItem = {
   title: string;
@@ -76,21 +82,31 @@ const validateOutline = (outline: unknown): outline is Outline => {
     return false;
   }
 
-  const noDuplicateIds = new Set(typedSections.map((s) => s.id)).size === typedSections.length;
-  const minWords = typedSections.reduce((sum, s) => sum + s.targetWordCount, 0) >= 800;
+  const noDuplicateIds =
+    new Set(typedSections.map((s) => s.id)).size === typedSections.length;
+  const minWords =
+    typedSections.reduce((sum, s) => sum + s.targetWordCount, 0) >= 800;
 
   return noDuplicateIds && minWords;
 };
 
-const countStructureElements = (text: string): { headings: number; lists: number } => ({
+const countStructureElements = (
+  text: string,
+): { headings: number; lists: number } => ({
   headings: (text.match(/^(##|###)\s/gm) || []).length,
-  lists: (text.match(/^[-*]\s/gm) || []).length
+  lists: (text.match(/^[-*]\s/gm) || []).length,
 });
 
-const structuresMatch = (text1: string, text2: string, tolerance = 2): boolean => {
+const structuresMatch = (
+  text1: string,
+  text2: string,
+  tolerance = 2,
+): boolean => {
   const s1 = countStructureElements(text1);
   const s2 = countStructureElements(text2);
-  return s1.headings === s2.headings && Math.abs(s1.lists - s2.lists) <= tolerance;
+  return (
+    s1.headings === s2.headings && Math.abs(s1.lists - s2.lists) <= tolerance
+  );
 };
 
 const logVerbose = (msg: string): void =>
@@ -98,10 +114,13 @@ const logVerbose = (msg: string): void =>
 
 const LANGUAGE_TRANSLATION_RULES: Partial<Record<LanguageCode, string>> = {
   ja: "Output ONLY Japanese. Do not include English, Chinese, or Arabic sentences except product names and URLs.",
-  ar: "Output ONLY Modern Standard Arabic (الفصحى). Do not include Chinese, Japanese, or English sentences except product names and URLs."
+  ar: "Output ONLY Modern Standard Arabic (الفصحى). Do not include Chinese, Japanese, or English sentences except product names and URLs.",
 };
 
-const hasCrossLanguageArtifacts = (lang: LanguageCode, text: string): boolean => {
+const hasCrossLanguageArtifacts = (
+  lang: LanguageCode,
+  text: string,
+): boolean => {
   if (lang === "ar") {
     return /[\u3040-\u30ff\u4e00-\u9fff]/u.test(text);
   }
@@ -115,15 +134,16 @@ async function retryOutlineGeneration(
   sources: SourceItem[],
   constraint: string,
   dateString: string,
-  categorySlug: string
+  categorySlug: string,
 ): Promise<Outline> {
   const attempts = [0, 1, 2];
   const errors: string[] = [];
 
   for (const attempt of attempts) {
-    const retryMsg = attempt > 0
-      ? "\nThe previous outline was rejected. Ensure every section has id, title, intent, and targetWordCount fields."
-      : "";
+    const retryMsg =
+      attempt > 0
+        ? "\nThe previous outline was rejected. Ensure every section has id, title, intent, and targetWordCount fields."
+        : "";
 
     const userPrompt = `
 Sources:
@@ -145,9 +165,12 @@ Return JSON only.
       const raw = await callAi(
         `${SYSTEM_RULES}\nTask: Create a staged article outline for ${dateString} category ${categorySlug}.`,
         userPrompt,
-        { responseFormat: { type: "json_object" } }
+        { responseFormat: { type: "json_object" } },
       );
-      const parsed = await parseJsonWithRepair({ text: raw, label: "outline generation" });
+      const parsed = await parseJsonWithRepair({
+        text: raw,
+        label: "outline generation",
+      });
 
       if (!validateOutline(parsed)) {
         const outline = parsed as { sections?: unknown[] };
@@ -156,9 +179,10 @@ Return JSON only.
             ? "Sections array must have at least 3 items"
             : outline.sections.some((s) => !validateSection(s))
               ? "Missing required section fields"
-              : new Set((outline.sections as OutlineSection[]).map((s) => s.id)).size !== outline.sections.length
+              : new Set((outline.sections as OutlineSection[]).map((s) => s.id))
+                    .size !== outline.sections.length
                 ? "Duplicate section ids"
-                : "total targetWordCount < 800"
+                : "total targetWordCount < 800",
         );
       }
 
@@ -166,17 +190,21 @@ Return JSON only.
     } catch (e: unknown) {
       const message = asErrorMessage(e);
       errors.push(message);
-      console.warn(`[daily-trends] outline validation failed on attempt ${attempt}: ${message}`);
+      console.warn(
+        `[daily-trends] outline validation failed on attempt ${attempt}: ${message}`,
+      );
     }
   }
 
-  throw new Error(`Outline generation failed after retries: ${errors.join(" | ")}`);
+  throw new Error(
+    `Outline generation failed after retries: ${errors.join(" | ")}`,
+  );
 }
 
 export async function generateOutline({
   dateString,
   sources,
-  categorySlug
+  categorySlug,
 }: {
   dateString: string;
   sources: SourceItem[];
@@ -184,7 +212,12 @@ export async function generateOutline({
 }): Promise<Outline> {
   const stageId = startStage("generateOutline", { dateString, categorySlug });
   try {
-    const outline = await retryOutlineGeneration(sources, CONTENT_CONSTRAINTS, dateString, categorySlug);
+    const outline = await retryOutlineGeneration(
+      sources,
+      CONTENT_CONSTRAINTS,
+      dateString,
+      categorySlug,
+    );
     endStage(stageId, { sections: outline.sections.length });
     return outline;
   } catch (error: unknown) {
@@ -197,13 +230,16 @@ export async function generateSection(
   section: OutlineSection,
   sources: SourceItem[],
   outline: Outline,
-  previousSectionSummaries: SectionSummary[]
+  previousSectionSummaries: SectionSummary[],
 ): Promise<string> {
   const stageId = startStage("generateSection", { sectionId: section.id });
   const systemPrompt = `${SYSTEM_RULES}\nEnglish Section Generator: ${section.title}`;
-  const summariesText = previousSectionSummaries.length > 0
-    ? previousSectionSummaries.map((s) => `[${s.id}]: ${s.summary}`).join("\n")
-    : "None yet.";
+  const summariesText =
+    previousSectionSummaries.length > 0
+      ? previousSectionSummaries
+          .map((s) => `[${s.id}]: ${s.summary}`)
+          .join("\n")
+      : "None yet.";
 
   const userPrompt = `
 Section ID: ${section.id}
@@ -230,24 +266,28 @@ Return JSON { "body": "Markdown string" }
 `;
   logVerbose(`[VERBOSE] section [${section.id}] prompt:\n${userPrompt}\n`);
 
-  const raw = await callAi(systemPrompt, userPrompt, { responseFormat: { type: "json_object" } });
-  const res = await parseJsonWithRepair({ text: raw, label: `section [${section.id}] en` }) as { body?: string };
+  const raw = await callAi(systemPrompt, userPrompt, {
+    responseFormat: { type: "json_object" },
+  });
+  const res = (await parseJsonWithRepair({
+    text: raw,
+    label: `section [${section.id}] en`,
+  })) as { body?: string };
   endStage(stageId);
   return res.body ?? "";
 }
 
-const retryTranslation = (
-  lang: LanguageCode,
-  sectionId: string,
-  enBody: string,
-  attempt = 0
-) => async (): Promise<string> => {
-  const retryMsg = attempt > 0
-    ? "\nThe previous translation had structural or language issues. Preserve structure and output ONLY the target language."
-    : "";
-  const languageRule = LANGUAGE_TRANSLATION_RULES[lang] ?? `Output ONLY ${lang}.`;
+const retryTranslation =
+  (lang: LanguageCode, sectionId: string, enBody: string, attempt = 0) =>
+  async (): Promise<string> => {
+    const retryMsg =
+      attempt > 0
+        ? "\nThe previous translation had structural or language issues. Preserve structure and output ONLY the target language."
+        : "";
+    const languageRule =
+      LANGUAGE_TRANSLATION_RULES[lang] ?? `Output ONLY ${lang}.`;
 
-  const userPrompt = `
+    const userPrompt = `
 Translate to ${lang}:
 ${enBody}
 
@@ -258,35 +298,53 @@ ${retryMsg}
 Return JSON { "body": "Markdown string" }
 `;
 
-  const raw = await callAi(
-    `${SYSTEM_RULES}\nTranslation: Senior tech editor for ${lang}.`,
-    userPrompt,
-    { responseFormat: { type: "json_object" } }
-  );
-  const res = await parseJsonWithRepair({ text: raw, label: `section [${sectionId}] ${lang}` }) as { body?: string };
-  const body = res.body ?? "";
-  const hasArtifacts = hasCrossLanguageArtifacts(lang, body);
+    const raw = await callAi(
+      `${SYSTEM_RULES}\nTranslation: Senior tech editor for ${lang}.`,
+      userPrompt,
+      { responseFormat: { type: "json_object" } },
+    );
+    const res = (await parseJsonWithRepair({
+      text: raw,
+      label: `section [${sectionId}] ${lang}`,
+    })) as { body?: string };
+    const body = res.body ?? "";
+    const hasArtifacts = hasCrossLanguageArtifacts(lang, body);
 
-  return (structuresMatch(body, enBody) && body.trim() && !hasArtifacts)
-    ? body
-    : attempt < 1
-      ? await retryTranslation(lang, sectionId, enBody, attempt + 1)()
-      : body;
-};
+    return structuresMatch(body, enBody) && body.trim() && !hasArtifacts
+      ? body
+      : attempt < 1
+        ? await retryTranslation(lang, sectionId, enBody, attempt + 1)()
+        : body;
+  };
 
-export async function translateSection(enBody: string, lang: LanguageCode, sectionId: string): Promise<string> {
+export async function translateSection(
+  enBody: string,
+  lang: LanguageCode,
+  sectionId: string,
+): Promise<string> {
   const stageId = startStage("translateSection", { sectionId, lang });
   const finalBody = await retryTranslation(lang, sectionId, enBody)();
 
   const hasArtifacts = hasCrossLanguageArtifacts(lang, finalBody);
-  const isValid = Boolean(finalBody.trim() && structuresMatch(finalBody, enBody) && !hasArtifacts);
-  void (!isValid && console.warn(`[daily-trends] translation parity/language check failed for ${lang} section ${sectionId}. Continuing anyway.`));
+  const isValid = Boolean(
+    finalBody.trim() && structuresMatch(finalBody, enBody) && !hasArtifacts,
+  );
+  void (
+    !isValid &&
+    console.warn(
+      `[daily-trends] translation parity/language check failed for ${lang} section ${sectionId}. Continuing anyway.`,
+    )
+  );
 
   endStage(stageId);
   return isValid ? finalBody : "Translation incomplete.";
 }
 
-export async function expandSection(sectionId: string, currentBody: string, lang: LanguageCode): Promise<string> {
+export async function expandSection(
+  sectionId: string,
+  currentBody: string,
+  lang: LanguageCode,
+): Promise<string> {
   const stageId = startStage("expandSection", { sectionId, lang });
   const userPrompt = `
 Language: ${lang}
@@ -300,9 +358,12 @@ Return JSON { "body": "Updated markdown string" }
   const raw = await callAi(
     `${SYSTEM_RULES}\nContent Evolution: Add 30% more technical depth to this section.`,
     userPrompt,
-    { responseFormat: { type: "json_object" } }
+    { responseFormat: { type: "json_object" } },
   );
-  const res = await parseJsonWithRepair({ text: raw, label: `expansion [${sectionId}] ${lang}` }) as { body?: string };
+  const res = (await parseJsonWithRepair({
+    text: raw,
+    label: `expansion [${sectionId}] ${lang}`,
+  })) as { body?: string };
   endStage(stageId);
   return res.body ?? currentBody;
 }
@@ -312,12 +373,17 @@ async function generateSectionWithSummary(
   sources: SourceItem[],
   outline: Outline,
   completedEn: SectionSummary[],
-  stagedContent: StagedContent
+  stagedContent: StagedContent,
 ): Promise<void> {
-  void ((AiState.totalTokensUsed > MAX_TOKENS_PER_RUN) && (() => {
-    console.log("[COST GUARD] Token limit reached. Assembling article with sections completed so far.");
-    throw new Error("TOKEN_LIMIT_REACHED");
-  })());
+  void (
+    AiState.totalTokensUsed > MAX_TOKENS_PER_RUN &&
+    (() => {
+      console.log(
+        "[COST GUARD] Token limit reached. Assembling article with sections completed so far.",
+      );
+      throw new Error("TOKEN_LIMIT_REACHED");
+    })()
+  );
 
   console.log(`[daily-trends] creating section ${section.id}...`);
   const en = await generateSection(section, sources, outline, completedEn);
@@ -326,20 +392,32 @@ async function generateSectionWithSummary(
   const summaryRaw = await callAi(
     "You are a summarizer.",
     `Summarize this in 2-3 sentences:\n${en.slice(0, 2000)}\nReturn JSON { "summary": "..." }`,
-    { responseFormat: { type: "json_object" } }
+    { responseFormat: { type: "json_object" } },
   );
-  const summaryRes = await parseJsonWithRepair({ text: summaryRaw, label: `summary [${section.id}]` }) as { summary?: string };
+  const summaryRes = (await parseJsonWithRepair({
+    text: summaryRaw,
+    label: `summary [${section.id}]`,
+  })) as { summary?: string };
   completedEn.push({ id: section.id, summary: summaryRes.summary ?? "" });
 
-  const translationLanguages = stagedContent.targetLanguages.filter((lang) => lang !== "en");
+  const translationLanguages = stagedContent.targetLanguages.filter(
+    (lang) => lang !== "en",
+  );
   await Promise.all(
     translationLanguages.map(async (lang) => {
-      stagedContent[lang].sections[section.id] = await translateSection(en, lang, section.id);
-    })
+      stagedContent[lang].sections[section.id] = await translateSection(
+        en,
+        lang,
+        section.id,
+      );
+    }),
   );
 }
 
-async function expandUndersizedContent(lang: LanguageCode, stagedContent: StagedContent): Promise<void> {
+async function expandUndersizedContent(
+  lang: LanguageCode,
+  stagedContent: StagedContent,
+): Promise<void> {
   let total = computeWordCounts(stagedContent[lang].sections, lang);
   let attempts = 0;
 
@@ -353,8 +431,14 @@ async function expandUndersizedContent(lang: LanguageCode, stagedContent: Staged
     if (targets.length === 0) return false;
 
     const targetId = targets[0];
-    console.log(`[daily-trends] ${lang} under length (${total}w), expanding ${targetId}...`);
-    stagedContent[lang].sections[targetId] = await expandSection(targetId, stagedContent[lang].sections[targetId], lang);
+    console.log(
+      `[daily-trends] ${lang} under length (${total}w), expanding ${targetId}...`,
+    );
+    stagedContent[lang].sections[targetId] = await expandSection(
+      targetId,
+      stagedContent[lang].sections[targetId],
+      lang,
+    );
     total = computeWordCounts(stagedContent[lang].sections, lang);
     attempts++;
     return true;
@@ -368,20 +452,26 @@ async function expandUndersizedContent(lang: LanguageCode, stagedContent: Staged
 
 async function polishAllLanguages(
   stagedContent: StagedContent,
-  processingLanguages: LanguageCode[]
+  processingLanguages: LanguageCode[],
 ): Promise<void> {
   await Promise.all(
     processingLanguages.map(async (lang) => {
       const fullBody = Object.values(stagedContent[lang].sections).join("\n\n");
       stagedContent[lang].title = await polishMetadata(fullBody, lang, "title");
-      stagedContent[lang].excerpt = await polishMetadata(fullBody, lang, "excerpt");
-    })
+      stagedContent[lang].excerpt = await polishMetadata(
+        fullBody,
+        lang,
+        "excerpt",
+      );
+    }),
   );
 }
 
-const normalizeTargetLanguages = (targetLanguages: readonly LanguageCode[] = LANGUAGE_ORDER): LanguageCode[] => {
+const normalizeTargetLanguages = (
+  targetLanguages: readonly LanguageCode[] = LANGUAGE_ORDER,
+): LanguageCode[] => {
   const filtered = targetLanguages.filter((lang): lang is LanguageCode =>
-    (LANGUAGE_ORDER as readonly string[]).includes(lang)
+    (LANGUAGE_ORDER as readonly string[]).includes(lang),
   );
   return filtered.length > 0 ? [...new Set(filtered)] : [...LANGUAGE_ORDER];
 };
@@ -389,36 +479,60 @@ const normalizeTargetLanguages = (targetLanguages: readonly LanguageCode[] = LAN
 export async function createStagedArticle({
   dateString,
   sources,
-  targetLanguages = LANGUAGE_ORDER
+  targetLanguages = LANGUAGE_ORDER,
+  preferredCategorySlug = null,
 }: {
   dateString: string;
   sources: SourceItem[];
   targetLanguages?: readonly LanguageCode[];
+  preferredCategorySlug?: string | null;
 }) {
   const selectedLanguages = normalizeTargetLanguages(targetLanguages);
-  const processingLanguages: LanguageCode[] = [...new Set(["en", ...selectedLanguages] as LanguageCode[])];
-  const category = pickCategory(null, sources);
-  const outline = await generateOutline({ dateString, sources, categorySlug: category.slug });
+  const processingLanguages: LanguageCode[] = [
+    ...new Set(["en", ...selectedLanguages] as LanguageCode[]),
+  ];
+  const preferredCategory = preferredCategorySlug
+    ? (ConfigState.CATEGORY_MAP.get(preferredCategorySlug) ?? null)
+    : null;
+  const category = pickCategory(preferredCategory, sources);
+  const outline = await generateOutline({
+    dateString,
+    sources,
+    categorySlug: category.slug,
+  });
 
   const stagedContent: StagedContent = {
     en: { sections: {} },
     ja: { sections: {} },
     ar: { sections: {} },
-    targetLanguages: selectedLanguages
+    targetLanguages: selectedLanguages,
   };
 
   const completedEn: SectionSummary[] = [];
 
   try {
     for (const section of outline.sections) {
-      await generateSectionWithSummary(section, sources, outline, completedEn, stagedContent);
+      await generateSectionWithSummary(
+        section,
+        sources,
+        outline,
+        completedEn,
+        stagedContent,
+      );
     }
   } catch (e: unknown) {
-    void ((asErrorMessage(e) !== "TOKEN_LIMIT_REACHED") && (() => { throw e; })());
+    void (
+      asErrorMessage(e) !== "TOKEN_LIMIT_REACHED" &&
+      (() => {
+        throw e;
+      })()
+    );
   }
 
   await Promise.all(
-    processingLanguages.map((lang) => expandUndersizedContent(lang, stagedContent))
+    processingLanguages.map((lang) =>
+      expandUndersizedContent(lang, stagedContent),
+    ),
   );
 
   await polishAllLanguages(stagedContent, processingLanguages);

--- a/scripts/lib/feed.ts
+++ b/scripts/lib/feed.ts
@@ -6,12 +6,16 @@ const FEED_ITEM_REGEX = /<item>([\s\S]*?)<\/item>/gi;
 const TITLE_REGEX = /<title>([\s\S]*?)<\/title>/i;
 const LINK_REGEX = /<link>([\s\S]*?)<\/link>/i;
 const DESCRIPTION_REGEX = /<description>([\s\S]*?)<\/description>/i;
+const PUB_DATE_REGEX = /<pubDate>([\s\S]*?)<\/pubDate>/i;
+const UPDATED_REGEX = /<updated>([\s\S]*?)<\/updated>/i;
+const DC_DATE_REGEX = /<dc:date>([\s\S]*?)<\/dc:date>/i;
 
 export type FeedItem = {
   feed: string;
   title: string;
   link: string;
   description?: string;
+  publishedAt?: string;
 };
 
 const sanitizeFeedText = (raw?: string) =>
@@ -19,13 +23,24 @@ const sanitizeFeedText = (raw?: string) =>
     ? he.decode(stripTags(raw))
     : raw;
 
+const normalizePublishedAt = (raw?: string): string | undefined => {
+  if (!raw) return undefined;
+  const parsed = new Date(raw);
+  return Number.isNaN(parsed.getTime()) ? undefined : parsed.toISOString();
+};
+
 const extractFeedItem = (itemXml: string, feedName: string): FeedItem | null => {
   const title = sanitizeFeedText(itemXml.match(TITLE_REGEX)?.[1]);
   const link = itemXml.match(LINK_REGEX)?.[1];
   const description = sanitizeFeedText(itemXml.match(DESCRIPTION_REGEX)?.[1]);
+  const publishedAt = normalizePublishedAt(
+    itemXml.match(PUB_DATE_REGEX)?.[1]
+      ?? itemXml.match(UPDATED_REGEX)?.[1]
+      ?? itemXml.match(DC_DATE_REGEX)?.[1]
+  );
 
   return (title && link)
-    ? { feed: feedName, title, link, description }
+    ? { feed: feedName, title, link, description, publishedAt }
     : null;
 };
 

--- a/scripts/lib/utils.ts
+++ b/scripts/lib/utils.ts
@@ -2,37 +2,70 @@ import { callAi, parseJsonWithRepair } from "./ai";
 import { SYSTEM_RULES } from "./constants";
 import { ConfigState } from "./config";
 
-const LANGUAGE_WORD_DENOMINATORS = { ja: 2.5 };
+const LANGUAGE_WORD_DENOMINATORS: Partial<Record<string, number>> = { ja: 2.5 };
 
-export function countWords(text, lang) {
+type SourceItem = {
+  title: string;
+  summary?: string;
+};
+
+type CategoryDefinition = (typeof ConfigState.CATEGORY_DEFINITIONS)[number];
+
+const normalize = (value: string): string =>
+  value.normalize("NFKC").trim().toLowerCase();
+
+export function countWords(text: string, lang: string): number {
   const denominator = LANGUAGE_WORD_DENOMINATORS[lang];
   return denominator
     ? Math.round(text.length / denominator)
     : text.split(/\s+/).filter(Boolean).length;
 }
 
-export function computeWordCounts(sections, lang) {
+export function computeWordCounts(sections: Record<string, string>, lang: string): number {
   return countWords(Object.values(sections).join("\n"), lang);
 }
 
-export function selectSectionsToExpand(sections) {
+export function selectSectionsToExpand(sections: Record<string, string>): string[] {
   return Object.entries(sections)
     .filter(([id]) => id.startsWith("trend"))
     .map(([id]) => id);
 }
 
-export async function polishMetadata(b, l, t) {
+export async function polishMetadata(
+  body: string,
+  language: string,
+  metadataType: "title" | "excerpt"
+): Promise<string> {
   const raw = await callAi(
-    `${SYSTEM_RULES}\nGenerate ${t} for the content.`,
-    `Language: ${l}\nContent: ${b.slice(0, 3000)}\nReturn JSON { "result": "..." }`,
+    `${SYSTEM_RULES}\nGenerate ${metadataType} for the content.`,
+    `Language: ${language}\nContent: ${body.slice(0, 3000)}\nReturn JSON { "result": "..." }`,
     { responseFormat: { type: "json_object" } }
   );
-  return (await parseJsonWithRepair({ text: raw, label: `polish ${t}` })).result;
+  return (await parseJsonWithRepair({ text: raw, label: `polish ${metadataType}` })).result;
 }
 
-export function pickCategory(_, sources) {
+export function resolveCategoryByInput(input: string): CategoryDefinition | null {
+  const normalizedInput = normalize(input);
+  return ConfigState.CATEGORY_DEFINITIONS.find((category) =>
+    [
+      category.slug,
+      category.nameEn,
+      category.nameJa,
+      category.nameAr,
+    ].some((value) => normalize(String(value)) === normalizedInput)
+  ) ?? null;
+}
+
+export function pickCategory(
+  preferredCategory: CategoryDefinition | null,
+  sources: SourceItem[]
+): CategoryDefinition {
+  if (preferredCategory) {
+    return preferredCategory;
+  }
+
   const aggregatedContent = sources
-    .map(x => `${x.title}${x.summary}`.toLowerCase())
+    .map((x) => `${x.title} ${x.summary ?? ""}`.toLowerCase())
     .join(" ");
 
   return ConfigState.CATEGORY_DEFINITIONS

--- a/scripts/list-categories-with-counts.ts
+++ b/scripts/list-categories-with-counts.ts
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+import { categories } from "./config/categories.js";
+
+const POSTS_DIR = path.join(process.cwd(), "src/content/posts");
+
+// Build a map from any language name to the canonical slug
+const categoryNameToSlug = new Map<string, string>();
+for (const cat of categories) {
+  categoryNameToSlug.set(cat.nameEn, cat.slug);
+  categoryNameToSlug.set(cat.nameJa, cat.slug);
+  categoryNameToSlug.set(cat.nameAr, cat.slug);
+}
+
+// Add aliases for commonly used shorter names
+categoryNameToSlug.set("Next.js", "next.js");
+
+function getBaseSlug(filename: string): string {
+  return filename
+    .replace(/\.mdx$/, "")
+    .replace(/-ar$/, "")
+    .replace(/-ja$/, "");
+}
+
+function parseCategoryFromFrontmatter(content: string): string | null {
+  const match = content.match(/^---\s*\n([\s\S]*?)\n---/);
+  if (!match) return null;
+  const frontmatter = match[1];
+  const categoryMatch = frontmatter.match(/^category:\s*"?([^"\n]+)"?/m);
+  return categoryMatch?.[1]?.trim() ?? null;
+}
+
+function countPostsPerCategory(): Map<string, number> {
+  const counts = new Map<string, number>();
+  const seenBaseSlugs = new Set<string>();
+
+  const files = fs.readdirSync(POSTS_DIR).filter((f) => f.endsWith(".mdx"));
+
+  for (const file of files) {
+    const baseSlug = getBaseSlug(file);
+    if (seenBaseSlugs.has(baseSlug)) continue;
+    seenBaseSlugs.add(baseSlug);
+
+    const content = fs.readFileSync(path.join(POSTS_DIR, file), "utf-8");
+    const categoryName = parseCategoryFromFrontmatter(content);
+
+    if (categoryName) {
+      // Map any language name to the canonical slug
+      const slug = categoryNameToSlug.get(categoryName) ?? categoryName;
+      const current = counts.get(slug) ?? 0;
+      counts.set(slug, current + 1);
+    }
+  }
+
+  return counts;
+}
+
+function main(): void {
+  const postCounts = countPostsPerCategory();
+
+  console.log("Categories (with post counts):");
+  console.log("-".repeat(35));
+
+  for (const cat of categories) {
+    const count = postCounts.get(cat.slug) ?? 0;
+    const displayCount = count > 0 ? String(count) : "-";
+    console.log(`${cat.slug.padEnd(26)} ${displayCount.padStart(4)}`);
+  }
+
+  console.log("-".repeat(35));
+  const totalPosts = Array.from(postCounts.values()).reduce((a, b) => a + b, 0);
+  console.log(`Total categories: ${categories.length}`);
+  console.log(`Total posts: ${totalPosts}`);
+}
+
+main();


### PR DESCRIPTION
## Description

Implements a category-driven recent-news workflow that generates 3-language AI trend briefs based on categorized RSS sources.

- 17 content categories with multilingual names (en/ja/ar)
- Category-based source filtering by keywords  
- CLI flags: `--category=<slug>` and `--recent-days=<n>`
- 24 RSS feeds including regional sources (JP/AR)
- Staged pipeline generating EN/JA/AR content simultaneously

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have tested my changes locally
- [x] My changes generate no new warnings (TypeScript passes)