### PR TITLE
feat(config): add React style rules and 2026 AI trend keywords

### DIFF
--- a/.cursor/rules/content-style.mdc
+++ b/.cursor/rules/content-style.mdc
@@ -1,0 +1,37 @@
+# Multilingual Blog Content Style (NeoWhisper)
+
+## Scope
+
+- Applies to all .mdx blog posts
+- Especially in src/content/posts
+
+## Content Principles
+
+- **Language Alignment**: Heading structure and meaning must be identical across EN, JA, and AR versions.
+- **Multilingual Standards**:
+  - **Arabic**: Modern Standard Arabic (Fusha) only — no dialects.
+  - **Japanese**: Polite (Desu/Masu) and technical-natural (no translationese).
+  - **English**: Concise, professional, senior-expert tone.
+- **No Mixing**: Never mix languages in a single paragraph (except product names).
+
+## AdSense Quality Rules
+
+- **No Thin Content**: Each post must be substantial (~1000+ words across versions).
+- **No AI Clichés**: Avoid "rapidly evolving landscape," "testament to," or generic buzzwords.
+- **Truthfulness**:
+  - Never fabricate facts, benchmarks, or pricing.
+  - Use qualitative phrasing if exact numbers aren't in the provided sources.
+  - Clearly mark estimates or hypotheses as such.
+
+## Formatting Rules
+
+- **Markdown Hierachy**: Single H1 (frontmatter), use H2 for major sections.
+- **Tables**: Use standard markdown tables for data comparisons (like model rankings).
+- **Links**: Use @lang=ja or @lang=ar query params for localized external references.
+
+## AI Instructions
+
+1. Preserve markdown structure and heading parity across all translations.
+2. Check word count and ensure value-adding substantial content.
+3. Label all non-sourced metrics as example/estimate.
+4. Output diff only for existing posts.

--- a/.cursor/rules/react-ts-style.mdc
+++ b/.cursor/rules/react-ts-style.mdc
@@ -1,0 +1,44 @@
+# React + TypeScript Style Rules (NeoWhisper Blog)
+
+## Scope
+
+- Applies to all .tsx and .ts files
+- Especially components, pages, and hooks
+
+## Core Principles
+
+- Always use functional components with hooks
+- **Server Components First**: Prefer Server Components; use 'use client' and hooks ONLY when interactivity is required.
+- Prefer shadcn/ui components when available
+- No new dependencies unless absolutely necessary and approved
+- Keep components small and single-responsibility
+- Use existing naming conventions (@/ alias for imports)
+
+## TypeScript Rules
+
+- Strict mode only — no any, no implicit any
+- Use interface for props, type for everything else
+- Prefer const assertions and as const when possible
+- Export types/interfaces at top level when reused
+
+## React Rules
+
+- Always use function component syntax (no class components)
+- Hooks must be at top level, no conditional hooks
+- All forms use react-hook-form + zod validation
+- No inline styles — use Tailwind only
+- Components must accept className prop and forward it (cn utility)
+
+## File Structure
+
+- Keep related files close (component + test + story in same folder)
+- Use @/ alias for imports (never relative paths deeper than 2 levels)
+
+## AI Instructions
+
+Before suggesting any change:
+1. Read this rule file
+2. Check existing code style in the same folder
+3. Only suggest changes that match the current project flow
+4. Never introduce new libraries or patterns without explicit approval
+5. Output diff only, never full file unless asked

--- a/scripts/config/categories.ts
+++ b/scripts/config/categories.ts
@@ -42,7 +42,14 @@ export const categories: CategoryConfig[] = [
       "prompt",
       "rag",
       "vector",
-      "embedding"
+      "embedding",
+      "ollama",
+      "agentic",
+      "reasoning",
+      "multimodality",
+      "rlvr",
+      "mlx",
+      "trends"
     ]
   },
   {

--- a/scripts/config/keywords.ts
+++ b/scripts/config/keywords.ts
@@ -21,6 +21,13 @@ export const keywords: KeywordBuckets = {
     "microsoft",
     "meta",
     "nvidia",
+    "ollama",
+    "gpt-5",
+    "claude 4",
+    "llama 4",
+    "gemini 3",
+    "grok",
+    "deepseek",
     "cloud",
     "developer",
     "cybersecurity",
@@ -29,6 +36,8 @@ export const keywords: KeywordBuckets = {
     "gpu",
     "inference",
     "api",
+    "rlvr",
+    "autonomous",
     "react",
     "next.js",
     "nextjs",
@@ -46,7 +55,8 @@ export const keywords: KeywordBuckets = {
     "database",
     "scaling",
     "saas",
-    "serverless"
+    "serverless",
+    "trends"
   ],
   "art": [
     "design",


### PR DESCRIPTION
## Summary
Updating the project's AI agent rules and keyword configurations.

## Changes
- **Editor Rules**: Added `.cursor/rules/react-ts-style.mdc` and `.cursor/rules/content-style.mdc`.
- **Keywords**: Expanded `ai-ml` category and global `trend` bucket with 2026 trends (Agentic AI, Reasoning, MLX, RLVR) and latest models (GPT-5.4, Claude 4.6, etc).
- **Ollama**: Explicitly added `ollama` to high-priority keywords.