### PR TITLE
chore(ci): automated backmerge workflow for main to dev and contents

### DIFF
--- a/.github/workflows/sync-branches.yml
+++ b/.github/workflows/sync-branches.yml
@@ -1,0 +1,46 @@
+name: Sync Main to Dev and Contents
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  backmerge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Fetch all history for all branches and tags
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Sync main into dev
+        run: |
+          # Checkout dev branch
+          git checkout dev || git checkout -b dev origin/dev
+          
+          # Merge main into dev (preferring main's history logically, though standard merge is fine)
+          git merge origin/main --no-edit -m "chore(sync): automated merge of main into dev"
+          
+          # Push the sync
+          git push origin dev
+        continue-on-error: true # Do not fail the workflow if there are merge conflicts
+
+      - name: Sync main into contents
+        run: |
+          # Checkout contents branch
+          git checkout contents || git checkout -b contents origin/contents
+          
+          # Merge main into contents
+          git merge origin/main --no-edit -m "chore(sync): automated merge of main into contents"
+          
+          # Push the sync
+          git push origin contents
+        continue-on-error: true

--- a/.github/workflows/sync-branches.yml
+++ b/.github/workflows/sync-branches.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   backmerge:
+    if: github.repository == 'NeoWhisper/neowhisper-blog'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/sync-branches.yml
+++ b/.github/workflows/sync-branches.yml
@@ -6,6 +6,9 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   backmerge:
     if: github.repository == 'NeoWhisper/neowhisper-blog'


### PR DESCRIPTION
## Description

This PR introduces `.github/workflows/sync-branches.yml`, a GitHub Actions workflow that automatically triggers whenever a change is pushed or merged into `main`.

### What it does:
- **Automatically merges `main` back down into `dev`** to prevent drift and ensure upcoming features sit on top of the latest hotfixes.
- **Automatically merges `main` back down into `contents`**, guaranteeing that automated daily blog generators don't regress any core layout changes.

### Review Guidelines:
This is a straightforward CI addition. Since backmerging failures are set to `continue-on-error: true`, transient merge conflicts will not fail the pipeline but instead allow manual intervention.