### PR TITLE
fix(newsletter): trigger on merged promotion PRs and avoid backfill

### DIFF
--- a/.github/workflows/send-subscriber-updates.yml
+++ b/.github/workflows/send-subscriber-updates.yml
@@ -6,6 +6,11 @@ on:
       - main
     paths:
       - "src/content/posts/**"
+  pull_request_target:
+    types:
+      - closed
+    branches:
+      - main
   workflow_dispatch:
 
 permissions:
@@ -17,11 +22,22 @@ concurrency:
 
 jobs:
   send:
+    if: >
+      github.event_name != 'pull_request_target' ||
+      (
+        github.event.pull_request.merged == true &&
+        (
+          github.event.pull_request.head.ref == 'contents' ||
+          github.event.pull_request.head.ref == 'dev'
+        )
+      )
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.merge_commit_sha || github.ref }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/scripts/send-subscriber-updates.ts
+++ b/scripts/send-subscriber-updates.ts
@@ -178,6 +178,29 @@ async function sendToSubscriber(subscriber: SubscriberRow, posts: HybridPost[]) 
   return true;
 }
 
+async function bootstrapSubscriberCursor(
+  subscriber: SubscriberRow,
+  latestPost: HybridPost,
+) {
+  const latestPublishedAt =
+    latestPost.publishedAt || latestPost.date || new Date().toISOString();
+  const update = await updateSubscriberLastSent(
+    subscriber.email,
+    latestPost.slug,
+    latestPublishedAt,
+  );
+  if (update.error) {
+    console.error(
+      `[send:subscribers] Failed to bootstrap cursor for ${subscriber.email}: ${update.error}`,
+    );
+    return false;
+  }
+  console.log(
+    `[send:subscribers] Bootstrapped cursor for ${subscriber.email} at ${latestPost.slug}`,
+  );
+  return true;
+}
+
 async function main() {
   let sentCount = 0;
 
@@ -194,6 +217,15 @@ async function main() {
 
     for (const subscriber of subscribers) {
       const lastSentTs = getLastSentTimestamp(subscriber);
+      if (lastSentTs === 0) {
+        // First-time subscribers should receive only future posts, not full history.
+        const latestPost = posts[0];
+        if (latestPost) {
+          await bootstrapSubscriberCursor(subscriber, latestPost);
+        }
+        continue;
+      }
+
       const newPosts = posts.filter((post) => getPostTimestamp(post) > lastSentTs);
       if (newPosts.length === 0) continue;
 


### PR DESCRIPTION
## What this changes

- Run subscriber workflow not only on direct  to  content files, but also when promotion PRs into  are merged ( or  heads).
- Avoid first-run historical blast: new subscribers with no cursor are bootstrapped to latest post and only receive future posts.

## Why

- Bot-authored promotion merges were not consistently triggering the existing push-path filter flow.
- First-time subscribers were receiving many old posts instead of only newly released ones.

## Validation

- 
> neowhisper-blog@1.14.2 lint
> eslint
- 
> neowhisper-blog@1.14.2 content:typecheck
> tsc -p tsconfig.scripts.json --noEmit
