### PR TITLE
fix(workflow): change pull_request_target to pull_request for security

### DIFF
--- a/.github/workflows/send-subscriber-updates.yml
+++ b/.github/workflows/send-subscriber-updates.yml
@@ -6,7 +6,7 @@ on:
       - main
     paths:
       - "src/content/posts/**"
-  pull_request_target:
+  pull_request:
     types:
       - closed
     branches:
@@ -23,7 +23,7 @@ concurrency:
 jobs:
   send:
     if: >
-      github.event_name != 'pull_request_target' ||
+      github.event_name != 'pull_request' ||
       (
         github.event.pull_request.merged == true &&
         (
@@ -32,12 +32,11 @@ jobs:
         )
       )
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.merge_commit_sha || github.ref }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.merge_commit_sha || github.ref }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6


### PR DESCRIPTION
## Summary
Changes the workflow trigger from `pull_request_target` to `pull_request` for improved security.

## Why
`pull_request_target` runs in the context of the base repository and has access to secrets, which can be a security risk if the workflow checks out untrusted code. 

`pull_request` runs in the context of the merge commit and is safer for workflows that don't need write access to the base repository.

## Changes
- Line 9: `pull_request_target:` → `pull_request:`
- Line 26: `github.event_name != 'pull_request_target'` → `github.event_name != 'pull_request'`
- Line 40: Same change in the checkout ref condition

## Impact
The workflow still triggers on:
- Push to `main` with content changes
- Merged PRs from `contents` or `dev` branches  
- Manual dispatch

No functional changes - just improved security posture.