### PR TITLE
fix: tighten adsense remediation indexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,36 @@ author:
 ---
 ```
 
+## AdSense Remediation Mode
+
+The site is currently optimized for a cleaner AdSense re-review corpus:
+
+- AI trend brief posts are conservative by default. Short briefs, and briefs
+  still using `/og-image.jpg`, are served with `noindex` and excluded from the
+  sitemap.
+- New staged posts must be more than 900 words before commit checks pass.
+- Keep generated briefs source-grounded, human-reviewed, and supported by a
+  distinctive cover image before allowing them into the index.
+
+Environment overrides:
+
+```env
+# Default: true. Set to false only after thin/generated briefs are remediated.
+BRIEF_NOINDEX_ENABLED=true
+
+# Default: 900. Hard floor: 600.
+BRIEF_NOINDEX_MIN_WORDS=900
+```
+
+Operational notes from local logs:
+
+- Recent daily content runs failed because local/remote model endpoints were
+  unavailable, overloaded, or too large for available system resources.
+- Treat generated trend posts as drafts until editorial QA confirms depth,
+  citations, image uniqueness, and language quality.
+- Keep `.logs/`, `scripts/logs/*.json`, and local audit reports out of commits;
+  summarize actionable findings in tracked docs instead.
+
 ## 🤖 Daily AI Content Automation (EN/JA/AR)
 
 This repository includes a multilingual draft generator that can run:

--- a/docs/adsense-remediation.md
+++ b/docs/adsense-remediation.md
@@ -1,0 +1,38 @@
+# AdSense Remediation Notes
+
+Last updated: 2026-05-07
+
+## Diagnosis
+
+The AdSense rejection `有用性の低いコンテンツ` is a content and UX quality issue,
+not primarily an OCSP Stapling issue. OCSP Stapling is useful TLS hardening, but
+it is not the likely cause of the AdSense rejection.
+
+## Repository Findings
+
+- The content library contains many AI trend brief posts, and many still use the
+  shared `/og-image.jpg` cover image.
+- Root planning docs and private audit files previously described the site as
+  AdSense-ready, but later audit/log evidence shows remediation is still active.
+- Local generation logs show repeated model availability/resource failures:
+  overloaded Ollama endpoint, LM Studio model load failure, connection timeout,
+  and unreachable local endpoint.
+- `.logs/`, `AUDIT_REPORTS/`, `TODO.md`, `IMMEDIATE_ACTIONS.md`, and DNS
+  checklist files are ignored or local-only; keep PR-ready decisions in tracked
+  docs and code.
+
+## Active Policy
+
+- Keep indexable content focused on stronger, human-reviewed articles.
+- Noindex AI trend briefs that are short or still use the generic cover image.
+- Exclude noindexed brief posts from the sitemap.
+- Require new posts to exceed 900 words before commit checks pass.
+
+## Before Reapplying
+
+- Verify `https://www.neowhisper.net/ads.txt` is reachable.
+- Verify sitemap excludes low-value brief posts.
+- Verify no indexable brief uses `/og-image.jpg`.
+- Confirm Privacy, Terms, About, Contact, and Editorial Policy pages are linked
+  and localized.
+- Re-run lint, unit tests, and build.

--- a/scripts/check-new-post-length.mjs
+++ b/scripts/check-new-post-length.mjs
@@ -4,7 +4,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import process from "node:process";
 
-const MIN_WORDS_EXCLUSIVE = 700; // Rule: strictly more than 700 words
+const MIN_WORDS_EXCLUSIVE = 900; // Rule: strictly more than 900 words
 const POSTS_DIR = "src/content/posts";
 
 function stripFrontmatter(source) {
@@ -100,7 +100,7 @@ async function main() {
     process.exit(0);
   }
 
-  console.error("Post length rule failed. New posts must be more than 700 words.");
+  console.error("Post length rule failed. New posts must be more than 900 words.");
   for (const failure of failures) {
     console.error(`- ${failure.file}: ${failure.wordCount} words`);
   }

--- a/src/app/(site)/blog/[slug]/page.tsx
+++ b/src/app/(site)/blog/[slug]/page.tsx
@@ -100,7 +100,11 @@ export async function generateMetadata({
       );
     });
 
-    const noIndex = isLowValueBriefPost(post.slug, post.content);
+    const noIndex = isLowValueBriefPost(
+      post.slug,
+      post.content,
+      post.coverImage,
+    );
     const canonicalUrl = buildPostUrl(post.slug, post.locale, post.source);
     const publishedTime = toIsoDate(post.publishedAt ?? post.date);
     const modifiedTime = toIsoDate(post.updatedAt ?? post.publishedAt ?? post.date);

--- a/src/lib/__tests__/brief-quality.test.ts
+++ b/src/lib/__tests__/brief-quality.test.ts
@@ -75,12 +75,34 @@ Outro text here.`;
       process.env.BRIEF_NOINDEX_ENABLED = originalEnv;
     });
 
-    test("returns false when BRIEF_NOINDEX_ENABLED is false (default)", () => {
-      // When feature flag is disabled, no posts are considered low-value
-      const content = "Short content.";
-      expect(isLowValueBriefPost("ai-trend-brief-2026-01-01", content)).toBe(
-        false,
+    test("returns true for brief posts using the generic cover image", () => {
+      const content = "Substantial content ".repeat(1000);
+      expect(
+        isLowValueBriefPost(
+          "ai-trend-brief-2026-01-01",
+          content,
+          "/og-image.jpg",
+        ),
+      ).toBe(true);
+    });
+
+    test("returns true for short brief posts by default", () => {
+      expect(
+        isLowValueBriefPost("ai-trend-brief-2026-01-01", "Short content."),
+      ).toBe(true);
+    });
+
+    test("returns false for substantial brief posts with a distinctive cover", () => {
+      const content = "Substantial content ".repeat(
+        EFFECTIVE_BRIEF_NOINDEX_THRESHOLD + 10,
       );
+      expect(
+        isLowValueBriefPost(
+          "ai-trend-brief-2026-01-01",
+          content,
+          "/images/distinctive-cover.png",
+        ),
+      ).toBe(false);
     });
 
     test("returns false for non-brief slugs even when enabled", () => {
@@ -112,13 +134,12 @@ Outro text here.`;
       });
     });
 
-    test("threshold defaults to 300 words minimum", () => {
-      expect(EFFECTIVE_BRIEF_NOINDEX_THRESHOLD).toBeGreaterThanOrEqual(300);
+    test("threshold defaults to 900 words minimum", () => {
+      expect(EFFECTIVE_BRIEF_NOINDEX_THRESHOLD).toBeGreaterThanOrEqual(900);
     });
 
-    test("threshold has hard floor of 150 words", () => {
-      // Threshold should never go below 150 even if env var is set lower
-      expect(EFFECTIVE_BRIEF_NOINDEX_THRESHOLD).toBeGreaterThanOrEqual(150);
+    test("threshold has hard floor of 600 words", () => {
+      expect(EFFECTIVE_BRIEF_NOINDEX_THRESHOLD).toBeGreaterThanOrEqual(600);
     });
   });
 

--- a/src/lib/brief-quality.ts
+++ b/src/lib/brief-quality.ts
@@ -6,20 +6,28 @@
  *  - src/app/sitemap.ts                   → exclude sub-threshold posts from sitemap
  *
  * Configuration via environment variables:
- *  - BRIEF_NOINDEX_ENABLED: Set to "true" to enable noindex for low-value briefs (default: false)
- *  - BRIEF_NOINDEX_MIN_WORDS: Minimum word count threshold (default: 300, floor: 150)
+ *  - BRIEF_NOINDEX_ENABLED: Set to "false" to disable low-value brief noindexing (default: true)
+ *  - BRIEF_NOINDEX_MIN_WORDS: Minimum word count threshold (default: 900, floor: 600)
  */
 
-// Feature flag: Set to "true" to enable noindex for sub-threshold brief posts.
-// Default is false to ensure all posts are indexed for AdSense compliance.
+const DEFAULT_BRIEF_NOINDEX_MIN_WORDS = 900;
+const BRIEF_NOINDEX_MIN_WORDS_FLOOR = 600;
+const GENERIC_BRIEF_COVER_IMAGE = "/og-image.jpg";
+
+// Feature flag: enabled by default while the AdSense remediation is active.
+// Set BRIEF_NOINDEX_ENABLED=false only after briefs have distinctive images,
+// source-grounded original analysis, and enough depth for policy review.
 export const BRIEF_NOINDEX_ENABLED =
-  process.env.BRIEF_NOINDEX_ENABLED === "true";
+  process.env.BRIEF_NOINDEX_ENABLED !== "false";
 
 // Emits noindex and excludes from sitemap if word count is below this threshold.
-// Lowered default to 300 words; enforce hard floor of 150 words minimum.
 export const EFFECTIVE_BRIEF_NOINDEX_THRESHOLD = Math.max(
-  150,
-  Number.parseInt(process.env.BRIEF_NOINDEX_MIN_WORDS ?? "300", 10),
+  BRIEF_NOINDEX_MIN_WORDS_FLOOR,
+  Number.parseInt(
+    process.env.BRIEF_NOINDEX_MIN_WORDS ??
+      String(DEFAULT_BRIEF_NOINDEX_MIN_WORDS),
+    10,
+  ),
 );
 
 /**
@@ -51,14 +59,19 @@ export function countPostWords(slug: string, content: string): number {
  * minimum word-count threshold for indexing.
  *
  * NOTE: This function respects the BRIEF_NOINDEX_ENABLED feature flag.
- * When disabled (default), all posts are considered indexable regardless of length.
+ * When disabled, all posts are considered indexable regardless of length.
  */
-export function isLowValueBriefPost(slug: string, content: string): boolean {
-  // Feature flag: disabled by default to ensure AdSense compliance
+export function isLowValueBriefPost(
+  slug: string,
+  content: string,
+  coverImage?: string | null,
+): boolean {
   if (!BRIEF_NOINDEX_ENABLED) return false;
 
   const isBrief = /(^|-)ai-(it-)?trend-brief-/.test(slug);
   if (!isBrief) return false;
+
+  if (coverImage === GENERIC_BRIEF_COVER_IMAGE) return true;
 
   const wordCount = countPostWords(slug, content);
   // Business rule: sub-threshold AI trend brief posts should not be indexed.

--- a/src/lib/posts-hybrid.ts
+++ b/src/lib/posts-hybrid.ts
@@ -14,6 +14,7 @@ import {
   getDynamicPostsByLocale,
 } from "@/lib/posts-dynamic";
 import type { Post } from "@/types";
+import { isLowValueBriefPost } from "@/lib/brief-quality";
 
 import { isLocalizedSlug } from "@/lib/slug";
 
@@ -176,12 +177,17 @@ export async function getHybridSitemapBlogEntries(): Promise<
     ...entry,
     source: "dynamic" as const,
   }));
-  const staticEntries = getPosts().map((post) => ({
-    slug: post.slug,
-    locale: normalizeLang(getPostLanguage(post.slug)),
-    lastModified: post.date ?? new Date().toISOString(),
-    source: "static" as const,
-  }));
+  const staticEntries = getPosts()
+    .filter(
+      (post) =>
+        !isLowValueBriefPost(post.slug, post.content, post.coverImage),
+    )
+    .map((post) => ({
+      slug: post.slug,
+      locale: normalizeLang(getPostLanguage(post.slug)),
+      lastModified: post.date ?? new Date().toISOString(),
+      source: "static" as const,
+    }));
 
   const combined = [...dynamicEntries, ...staticEntries];
   const seen = new Set<string>();


### PR DESCRIPTION
## Description

Tightens the AdSense remediation path by making low-value AI trend briefs conservative by default, excluding noindexed static briefs from the sitemap, raising the new-post length gate, and documenting root/docs/log findings in a tracked remediation note.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📝 Documentation update
- [ ] 🎨 Style/UI changes
- [ ] ♻️ Refactor (no functional changes)
- [ ] ⚡ Performance improvement

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have tested my changes locally
- [x] My changes generate no new warnings
- [x] I have updated the documentation accordingly

## Screenshots (if applicable)

N/A - no UI changes.

## Related Issues

AdSense low-value content remediation.