### PR TITLE
feat: truth-first repositioning for service identity

### DIFF
--- a/docs/truth-first-copy-policy.md
+++ b/docs/truth-first-copy-policy.md
@@ -1,0 +1,43 @@
+# Truth-First Copy Policy
+
+Last updated: 2026-05-07
+
+## Purpose
+
+Keep public messaging accurate, verifiable, and consistent across English, Japanese, and Arabic.
+NEO WHISPER is an IT services sole proprietorship, so service trust and delivery clarity take priority over promotional language.
+
+## Content State Contract
+
+Use one of these states for service and project items:
+
+- `now`: deliverable today.
+- `in_progress`: actively being built but not deliverable yet.
+- `planned`: future concept or roadmap item.
+
+Rendering rules:
+
+- `now` items appear in primary sections on homepage and services pages.
+- `in_progress` items appear only in clearly labeled secondary sections.
+- `planned` items appear only in explicitly labeled roadmap sections.
+
+## Claim Rules
+
+- Use `we provide` only for `now` items.
+- Use `we are building` for `in_progress` items.
+- Use `we plan to` for `planned` items.
+- Do not imply delivery maturity for non-`now` items.
+
+## Prohibited Patterns
+
+- Unsourced hard metrics (for example percentages, latency, user counts, revenue impact).
+- Vague superlatives without evidence (`industry-leading`, `world-class scale`, `guaranteed growth`).
+- Presenting roadmap ideas as current production capability.
+- Cross-language overclaiming where one locale promises more than another.
+
+## Recommended Patterns
+
+- Short scope boundaries: what is included and what is not included by default.
+- Practical process language: discovery -> scope -> build -> handoff.
+- Qualitative outcomes when audited metrics are unavailable.
+- Consistent claim strength and meaning in EN/JA/AR versions.

--- a/src/app/(site)/about/page.tsx
+++ b/src/app/(site)/about/page.tsx
@@ -8,10 +8,24 @@ const baseUrl = SITE_URL;
 const translations = {
   en: {
     label: "About",
-    title: "Registered IT Services Business",
+    title: "Professional Profile",
     subtitle: "Registered in Japan as an IT services sole proprietorship.",
-    intro: "NEO WHISPER is a registered IT services sole proprietorship based in Minato City, Tokyo, founded in December 2025 by Yousif Alqadi.",
+    intro: "NEO WHISPER is a Tokyo-based sole proprietorship delivering multilingual IT services with a truth-first operating approach.",
     back: "Back to Home",
+    identityTitle: "Business Identity",
+    identity: [
+      "Trade Name: NEO WHISPER",
+      "Founder: ALQADI YOUSIF MOHAMMED A",
+      "Business Category: IT Services (ITサービス業)",
+      "Opened: 2025-12",
+      "Location: Minato City, Tokyo",
+    ],
+    principlesTitle: "Operating Principles",
+    principles: [
+      "Truth-first delivery: no inflated claims, no unsupported numbers.",
+      "Multilingual execution: Japanese, English, and Arabic communication and production.",
+      "Practical scope control: clear deliverables from requirements to handoff.",
+    ],
     sections: [
       {
         title: "Who we are",
@@ -34,8 +48,22 @@ const translations = {
     label: "概要",
     title: "ITサービス個人事業",
     subtitle: "開業届上の職業区分: ITサービス業。",
-    intro: "NEO WHISPERは、2025年12月に東京都港区でアルカーディ ヨセフが開業したITサービス個人事業です。税務署へ開業届を提出済みです。",
+    intro: "NEO WHISPERは、東京を拠点に多言語でITサービスを提供する個人事業です。誇張のない実務重視の方針で運営しています。",
     back: "ホームへ戻る",
+    identityTitle: "事業者情報",
+    identity: [
+      "屋号: NEO WHISPER",
+      "代表者: ALQADI YOUSIF MOHAMMED A",
+      "職業区分: ITサービス業",
+      "開業: 2025年12月",
+      "所在地: 東京都港区",
+    ],
+    principlesTitle: "運営方針",
+    principles: [
+      "誇張しない説明: 根拠のない数値や実績表現を行わない。",
+      "多言語実行: 日本語・英語・アラビア語で一貫対応。",
+      "実務スコープ重視: 要件整理から引き渡しまでを明確化。",
+    ],
     sections: [
       {
         title: "私たちについて",
@@ -58,8 +86,22 @@ const translations = {
     label: "نبذة",
     title: "نشاط خدمات تقنية معلومات مسجل",
     subtitle: "نشاط مسجل في اليابان ضمن خدمات تقنية المعلومات.",
-    intro: "نيو ويسبر (NEO WHISPER) هي مؤسسة فردية مسجلة لخدمات تقنية المعلومات مقرها في مدينة ميناتو، طوكيو، تأسست في ديسمبر 2025 من قبل يوسف القاضي.",
+    intro: "نيو ويسبر (NEO WHISPER) مؤسسة فردية في طوكيو تقدم خدمات تقنية معلومات متعددة اللغات بمنهج عملي قائم على الدقة.",
     back: "العودة للرئيسية",
+    identityTitle: "الهوية المهنية",
+    identity: [
+      "الاسم التجاري: NEO WHISPER",
+      "المؤسس: ALQADI YOUSIF MOHAMMED A",
+      "فئة النشاط: خدمات تقنية معلومات (ITサービス業)",
+      "تاريخ البدء: 2025-12",
+      "الموقع: مدينة ميناتو، طوكيو",
+    ],
+    principlesTitle: "مبادئ التشغيل",
+    principles: [
+      "تنفيذ قائم على الحقيقة: بدون مبالغة وبدون أرقام غير موثقة.",
+      "تنفيذ متعدد اللغات: اليابانية والإنجليزية والعربية.",
+      "ضبط نطاق عملي: مخرجات واضحة من المتطلبات حتى التسليم.",
+    ],
     sections: [
       {
         title: "من نحن",
@@ -193,6 +235,24 @@ export default async function AboutPage({
           </p>
         </div>
 
+        <section className="mb-8 rounded-3xl border border-white/20 bg-white/60 p-8 backdrop-blur-lg dark:border-white/10 dark:bg-white/5">
+          <h2 className="text-2xl font-bold text-gray-900 dark:text-white">{t.identityTitle}</h2>
+          <ul className="mt-4 space-y-2 text-sm text-gray-700 dark:text-gray-300">
+            {t.identity.map((item) => (
+              <li key={item}>{item}</li>
+            ))}
+          </ul>
+        </section>
+
+        <section className="mb-12 rounded-3xl border border-white/20 bg-white/60 p-8 backdrop-blur-lg dark:border-white/10 dark:bg-white/5">
+          <h2 className="text-2xl font-bold text-gray-900 dark:text-white">{t.principlesTitle}</h2>
+          <ul className="mt-4 list-disc space-y-2 pl-5 text-sm text-gray-700 dark:text-gray-300">
+            {t.principles.map((item) => (
+              <li key={item}>{item}</li>
+            ))}
+          </ul>
+        </section>
+
         <div className="grid gap-6 md:grid-cols-3">
           {t.sections.map((section) => (
             <div key={section.title} className="rounded-3xl border border-white/20 bg-white/60 p-8 backdrop-blur-lg dark:border-white/10 dark:bg-white/5">
@@ -212,7 +272,7 @@ export default async function AboutPage({
                   Work with NEO WHISPER
                 </h2>
                 <p className="mt-2 text-sm text-gray-600 dark:text-gray-300">
-                  Ready to bridge the gap and build something world-class? Let&apos;s talk about your next project.
+                  If you need practical multilingual IT execution, let&apos;s discuss your next project.
                 </p>
               </div>
               <div className="flex flex-wrap gap-3">

--- a/src/app/(site)/page.tsx
+++ b/src/app/(site)/page.tsx
@@ -17,13 +17,13 @@ const siteUrl = SITE_URL;
 const translations = {
   en: {
     studio: "NEO WHISPER",
-    heroTitle: "Build software, launch websites, and scale globally.",
+    heroTitle: "Tokyo-based multilingual IT partner for practical software delivery.",
     heroSubtitle:
-      "Tokyo-based IT services business (JP/EN/AR) providing software development, game development, app development, web production, web content production, and translation.",
+      "We deliver software, web systems, and localization in Japanese, English, and Arabic for startups, SMEs, and creators.",
     visitBlog: "Visit the Blog",
-    viewProjects: "See Projects",
-    viewServices: "View Services",
-    servicesTitle: "Services",
+    viewProjects: "View Work",
+    viewServices: "Start a Project",
+    servicesTitle: "Now Delivering",
     projectsTitle: "Featured Projects",
     projectsCta: "See more →",
     downloadsTitle: "Products & Downloads",
@@ -40,10 +40,17 @@ const translations = {
     contactTitle: "Let's Build Together",
     contactCopy:
       "Tell us about your product or collaboration idea, and we'll help you scope the next steps.",
-    contactButton: "Contact Us",
+    contactButton: "Start a Project",
     readBlog: "Read the Blog",
     plannedLabel: "Planned",
     exploreServices: "Explore Services →",
+    nowStripTitle: "Now",
+    nowStrip: [
+      "Software and web application development",
+      "Web production and multilingual content systems",
+      "Technical translation and localization (JP/EN/AR)",
+      "Small-scope game prototype development",
+    ],
     services: [
       {
         title: "Software & App Development",
@@ -88,13 +95,13 @@ const translations = {
   },
   ja: {
     studio: "NEO WHISPER",
-    heroTitle: "ソフトウェアとWebを開発し、世界へ。",
+    heroTitle: "東京拠点の多言語IT開発パートナー。",
     heroSubtitle:
-      "東京都港区を拠点とするITサービス業。ソフトウェア開発・ゲーム開発・アプリ開発・Web制作・Webコンテンツ制作・翻訳などのITサービスを提供しています。",
+      "スタートアップ・中小企業・個人事業向けに、ソフトウェア開発、Web制作、多言語対応を提供します。",
     visitBlog: "ブログを見る",
-    viewProjects: "プロジェクトを見る",
-    viewServices: "サービスを見る",
-    servicesTitle: "サービス",
+    viewProjects: "実績を見る",
+    viewServices: "プロジェクト相談を始める",
+    servicesTitle: "現在提供中",
     projectsTitle: "注目プロジェクト",
     projectsCta: "もっと見る →",
     downloadsTitle: "プロダクト / ダウンロード",
@@ -111,10 +118,17 @@ const translations = {
     contactTitle: "一緒に作りましょう",
     contactCopy:
       "プロダクトやコラボレーションのご相談をお聞かせください。",
-    contactButton: "お問い合わせ",
+    contactButton: "プロジェクト相談を始める",
     readBlog: "ブログを読む",
     plannedLabel: "準備中",
     exploreServices: "サービスを見る →",
+    nowStripTitle: "Now",
+    nowStrip: [
+      "ソフトウェア・Webアプリ開発",
+      "Web制作・多言語コンテンツ基盤",
+      "技術翻訳・ローカライズ（JP/EN/AR）",
+      "小規模ゲームプロトタイプ開発",
+    ],
     services: [
       {
         title: "ソフトウェア・アプリ開発",
@@ -159,13 +173,13 @@ const translations = {
   },
   ar: {
     studio: "نيو ويسبر (NEO WHISPER)",
-    heroTitle: "نطوّر البرمجيات والويب ونتوسع عالميًا.",
+    heroTitle: "شريك تقني متعدد اللغات من طوكيو لتنفيذ برمجي عملي.",
     heroSubtitle:
-      "نشاط خدمات تقنية معلومات في طوكيو (اليابانية/الإنجليزية/العربية) يقدم تطوير البرمجيات والألعاب والتطبيقات وإنتاج الويب وإنتاج محتوى الويب والترجمة.",
+      "نقدّم تطوير البرمجيات وأنظمة الويب والتعريب باليابانية والإنجليزية والعربية للشركات الناشئة والصغيرة وصنّاع الأعمال.",
     visitBlog: "زيارة المدونة",
-    viewProjects: "عرض المشاريع",
-    viewServices: "عرض الخدمات",
-    servicesTitle: "الخدمات",
+    viewProjects: "عرض الأعمال",
+    viewServices: "ابدأ طلب مشروع",
+    servicesTitle: "متاح الآن",
     projectsTitle: "مشاريع مختارة",
     projectsCta: "المزيد →",
     downloadsTitle: "المنتجات والتنزيلات",
@@ -182,10 +196,17 @@ const translations = {
     contactTitle: "لنبدأ مشروعًا معًا",
     contactCopy:
       "أخبرنا عن فكرتك وسنساعدك في تحديد الخطوات القادمة.",
-    contactButton: "تواصل معنا",
+    contactButton: "ابدأ طلب مشروع",
     readBlog: "اقرأ المدونة",
     plannedLabel: "قريبًا",
     exploreServices: "استكشاف الخدمات →",
+    nowStripTitle: "Now",
+    nowStrip: [
+      "تطوير البرمجيات وتطبيقات الويب",
+      "إنتاج الويب وأنظمة المحتوى متعددة اللغات",
+      "الترجمة التقنية والتعريب (JP/EN/AR)",
+      "تطوير نماذج أولية صغيرة للألعاب",
+    ],
     services: [
       {
         title: "تطوير البرمجيات والتطبيقات",
@@ -314,6 +335,7 @@ export default async function Home({
   }).filter((post) => getBaseSlug(post.slug) !== "welcome");
   const posts = filteredPosts.slice(0, 3);
   const projects = getProjects(currentLang);
+  const nowProjects = projects.filter((project) => project.status === "now").slice(0, 3);
 
   return (
     <>
@@ -382,7 +404,7 @@ export default async function Home({
           </div>
         </header>
 
-        <section id="services" className="mb-16">
+        <section id="services" className="mb-8">
           <h2 className="mb-6 text-3xl font-extrabold text-gray-900 dark:text-white">
             {copy.servicesTitle}
           </h2>
@@ -412,6 +434,20 @@ export default async function Home({
           </div>
         </section>
 
+        <section className="mb-16 rounded-3xl border border-white/20 bg-white/60 p-6 shadow-lg backdrop-blur-lg dark:border-white/10 dark:bg-white/5">
+          <h2 className="text-lg font-bold text-gray-900 dark:text-white">{copy.nowStripTitle}</h2>
+          <ul className="mt-4 grid gap-3 md:grid-cols-2">
+            {copy.nowStrip.map((item) => (
+              <li
+                key={item}
+                className="rounded-xl border border-white/20 bg-white/70 px-4 py-3 text-sm text-gray-700 dark:border-white/10 dark:bg-white/10 dark:text-gray-200"
+              >
+                {item}
+              </li>
+            ))}
+          </ul>
+        </section>
+
         <section id="projects" className="mb-16">
           <div className="flex items-center justify-between gap-4 mb-6">
             <h2 className="text-3xl font-extrabold text-gray-900 dark:text-white">
@@ -425,23 +461,15 @@ export default async function Home({
             </Link>
           </div>
           <div className="grid gap-6 md:grid-cols-2">
-            {projects.map((item) => (
+            {nowProjects.map((item) => (
               <div
                 key={item.title}
-                className={`rounded-3xl border border-white/20 bg-white/60 p-6 shadow-lg backdrop-blur-lg transition-all duration-300 dark:border-white/10 dark:bg-white/5 ${item.status === "planned"
-                  ? "opacity-60 grayscale"
-                  : "hover:-translate-y-1 hover:shadow-xl"
-                  }`}
+                className="rounded-3xl border border-white/20 bg-white/60 p-6 shadow-lg backdrop-blur-lg transition-all duration-300 hover:-translate-y-1 hover:shadow-xl dark:border-white/10 dark:bg-white/5"
               >
                 <div className="flex items-center justify-between gap-3">
                   <h3 className="text-lg font-bold text-gray-900 dark:text-white">
                     {item.title}
                   </h3>
-                  {item.status === "planned" && (
-                    <span className="rounded-full border border-white/30 bg-white/70 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.2em] text-gray-600 dark:border-white/10 dark:bg-white/10 dark:text-gray-300">
-                      {copy.plannedLabel}
-                    </span>
-                  )}
                 </div>
                 <p className="mt-2 text-sm text-gray-600 dark:text-gray-300">
                   {item.description}

--- a/src/app/(site)/projects/page.tsx
+++ b/src/app/(site)/projects/page.tsx
@@ -10,39 +10,60 @@ const baseUrl = SITE_URL;
 const copy = {
   en: {
     label: "Projects",
-    title: "Selected Work",
-    subtitle: "Shipped projects and products in production.",
+    title: "Proof of Work",
+    subtitle: "Shipped implementation first, roadmap second.",
     intro:
-      "Live projects by NEO WHISPER, a registered IT services sole proprietorship in Tokyo.",
+      "Current shipped work by NEO WHISPER, a registered IT services sole proprietorship in Tokyo.",
     back: "Back to Home",
-    planned: "Planned",
-    liveSection: "Live Projects",
-    plannedSection: "Coming Soon",
-    plannedIntro: "Projects currently in development or planning phase.",
+    nowLabel: "Now",
+    inProgressLabel: "In Progress",
+    plannedLabel: "Planned",
+    nowSection: "Shipped Work",
+    roadmapSection: "Roadmap",
+    roadmapIntro: "These items are not yet delivered and are shown as future work only.",
+    primaryCta: "Start a Project",
+    challengeLabel: "Challenge",
+    scopeLabel: "Scope",
+    stackLabel: "Stack",
+    outcomeLabel: "Outcome",
   },
   ja: {
     label: "プロジェクト",
-    title: "選定プロジェクト",
-    subtitle: "リリース済みのプロジェクトと製品。",
+    title: "実績とロードマップ",
+    subtitle: "本番稼働中の実績を先に、将来計画を後に表示します。",
     intro:
-      "NEO WHISPER（東京都港区のITサービス個人事業主）による、本番環境で稼働中のプロジェクト。",
+      "NEO WHISPER（東京都港区のITサービス個人事業主）の現在の実装実績です。",
     back: "ホームへ戻る",
-    planned: "準備中",
-    liveSection: "稼働中のプロジェクト",
-    plannedSection: "開発中",
-    plannedIntro: "現在開発または計画中のプロジェクト。",
+    nowLabel: "提供中",
+    inProgressLabel: "進行中",
+    plannedLabel: "計画",
+    nowSection: "稼働中の実績",
+    roadmapSection: "ロードマップ",
+    roadmapIntro: "以下は未提供の将来項目です。現在提供中のサービスではありません。",
+    primaryCta: "プロジェクト相談を始める",
+    challengeLabel: "課題",
+    scopeLabel: "実装範囲",
+    stackLabel: "技術構成",
+    outcomeLabel: "成果",
   },
   ar: {
     label: "المشاريع",
-    title: "أعمال مختارة",
-    subtitle: "المشاريع والمنتجات المنشورة.",
+    title: "الأعمال المنفذة وخارطة الطريق",
+    subtitle: "نعرض ما تم تسليمه فعلياً أولاً، ثم العناصر المستقبلية بشكل منفصل.",
     intro:
-      "المشاريع الحية من نيو ويسبر (NEO WHISPER)، وهي مؤسسة فردية مسجلة لخدمات تقنية المعلومات في طوكيو.",
+      "هذه هي الأعمال المنفذة حالياً لدى نيو ويسبر (NEO WHISPER)، وهي مؤسسة فردية مسجلة لخدمات تقنية المعلومات في طوكيو.",
     back: "العودة للرئيسية",
-    planned: "قريبًا",
-    liveSection: "المشاريع الحية",
-    plannedSection: "قريباً",
-    plannedIntro: "المشاريع قيد التطوير أو التخطيط حالياً.",
+    nowLabel: "متاح الآن",
+    inProgressLabel: "قيد التنفيذ",
+    plannedLabel: "مخطط",
+    nowSection: "أعمال تم تسليمها",
+    roadmapSection: "خارطة الطريق",
+    roadmapIntro: "العناصر التالية غير مسلّمة بعد وتُعرض كخطط مستقبلية فقط.",
+    primaryCta: "ابدأ طلب مشروع",
+    challengeLabel: "التحدي",
+    scopeLabel: "نطاق التنفيذ",
+    stackLabel: "التقنيات",
+    outcomeLabel: "النتيجة",
   },
 } as const;
 
@@ -130,6 +151,8 @@ export default async function ProjectsPage({
       return { ...link, href: `${link.href}?lang=${currentLang}` };
     }),
   }));
+  const nowProjects = projects.filter((p) => p.status === "now");
+  const roadmapProjects = projects.filter((p) => p.status !== "now");
   return (
     <div
       className="min-h-screen bg-gradient-to-br from-gray-50 via-gray-100 to-gray-200 dark:from-gray-950 dark:via-gray-900 dark:to-slate-900 px-4 py-16 sm:px-6 lg:px-8"
@@ -160,15 +183,13 @@ export default async function ProjectsPage({
           </Link>
         </div>
 
-        {/* Live Projects Section */}
+        {/* Shipped Projects Section */}
         <section className="mb-16">
           <h2 className="mb-8 text-2xl font-bold text-gray-900 dark:text-white">
-            {t.liveSection}
+            {t.nowSection}
           </h2>
           <div className="grid gap-6 md:grid-cols-2">
-            {projects
-              .filter((p) => p.status === "live")
-              .map((project) => (
+            {nowProjects.map((project) => (
                 <article
                   key={project.title}
                   className="rounded-3xl border border-white/20 bg-white/60 p-6 shadow-lg backdrop-blur-lg transition-all duration-300 hover:-translate-y-1 hover:shadow-xl dark:border-white/10 dark:bg-white/5"
@@ -188,6 +209,26 @@ export default async function ProjectsPage({
                   <p className="mt-3 text-sm text-gray-600 dark:text-gray-300">
                     {project.description}
                   </p>
+                  {project.proof && (
+                    <dl className="mt-4 grid gap-2 rounded-2xl border border-white/20 bg-white/60 p-4 text-xs dark:border-white/10 dark:bg-white/5">
+                      <div>
+                        <dt className="font-semibold text-gray-700 dark:text-gray-200">{t.challengeLabel}</dt>
+                        <dd className="text-gray-600 dark:text-gray-300">{project.proof.challenge}</dd>
+                      </div>
+                      <div>
+                        <dt className="font-semibold text-gray-700 dark:text-gray-200">{t.scopeLabel}</dt>
+                        <dd className="text-gray-600 dark:text-gray-300">{project.proof.scope}</dd>
+                      </div>
+                      <div>
+                        <dt className="font-semibold text-gray-700 dark:text-gray-200">{t.stackLabel}</dt>
+                        <dd className="text-gray-600 dark:text-gray-300">{project.proof.stack}</dd>
+                      </div>
+                      <div>
+                        <dt className="font-semibold text-gray-700 dark:text-gray-200">{t.outcomeLabel}</dt>
+                        <dd className="text-gray-600 dark:text-gray-300">{project.proof.outcome}</dd>
+                      </div>
+                    </dl>
+                  )}
                   <div className="mt-4 flex flex-wrap gap-2">
                     {project.tags.map((tag) => (
                       <span
@@ -231,21 +272,19 @@ export default async function ProjectsPage({
           </div>
         </section>
 
-        {/* Planned Projects Section */}
-        {projects.some((p) => p.status === "planned") && (
+        {/* Roadmap Section */}
+        {roadmapProjects.length > 0 && (
           <section>
             <div className="mb-6 flex items-center gap-3">
               <h2 className="text-xl font-semibold text-gray-700 dark:text-gray-300">
-                {t.plannedSection}
+                {t.roadmapSection}
               </h2>
               <span className="text-sm text-gray-500 dark:text-gray-400">
-                {t.plannedIntro}
+                {t.roadmapIntro}
               </span>
             </div>
             <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-              {projects
-                .filter((p) => p.status === "planned")
-                .map((project) => (
+              {roadmapProjects.map((project) => (
                   <article
                     key={project.title}
                     className="rounded-2xl border border-white/20 bg-white/40 p-5 opacity-70 transition-all duration-300 dark:border-white/10 dark:bg-white/5"
@@ -255,7 +294,7 @@ export default async function ProjectsPage({
                         {project.title}
                       </h3>
                       <span className="rounded-full border border-white/30 bg-white/70 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.15em] text-gray-500 dark:border-white/10 dark:bg-white/10 dark:text-gray-400">
-                        {t.planned}
+                        {project.status === "in_progress" ? t.inProgressLabel : t.plannedLabel}
                       </span>
                     </div>
                     <p className="mt-2 text-sm text-gray-600 dark:text-gray-400 line-clamp-2">
@@ -276,6 +315,15 @@ export default async function ProjectsPage({
             </div>
           </section>
         )}
+
+        <div className="mt-12 flex justify-center">
+          <Link
+            href={`/contact?lang=${currentLang}`}
+            className="rounded-full bg-purple-600 px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-purple-500/20 transition-all duration-300 hover:scale-[1.02]"
+          >
+            {t.primaryCta}
+          </Link>
+        </div>
       </div>
     </div>
   );

--- a/src/app/(site)/services/page.tsx
+++ b/src/app/(site)/services/page.tsx
@@ -8,111 +8,139 @@ const baseUrl = SITE_URL;
 const translations = {
   en: {
     label: "Services",
-    title: "What We Deliver",
-    subtitle:
-      "Official IT services scope: software, games, apps, web/content production, and translation.",
+    title: "Now Delivering",
+    subtitle: "Current service scope you can request today.",
     back: "Back to Home",
-    cards: [
+    nowTitle: "Now Delivering",
+    inProgressTitle: "In Progress",
+    plannedTitle: "Planned",
+    flowTitle: "Delivery Flow",
+    flow: "Discovery -> Scope -> Build -> Handoff",
+    nowCards: [
       {
-        title: "Software & Tools Development",
+        title: "Software and Web Application Development",
         description:
-          "Custom software solutions, automation tools, and integrated systems for business operations.",
-        bullets: [
-          "Internal dashboards",
-          "Automation tools",
-          "API integrations",
-        ],
+          "Custom business systems, internal tools, and web applications tailored to operational needs.",
+        includes: "Includes: scope definition, implementation, testing, deployment support.",
+        excludes: "Not included by default: long-term 24/7 operations, enterprise compliance audits.",
       },
       {
         title: "Game Development",
         description:
-          "Interactive experiences and game prototypes built for engagement and polish.",
-        bullets: [
-          "Casual mobile prototypes",
-          "Indie game MVPs",
-          "Production vertical slices",
-        ],
+          "Casual mobile prototypes and small indie gameplay builds for concept validation.",
+        includes: "Includes: gameplay prototype, iteration passes, build packaging.",
+        excludes: "Not included by default: full live-ops pipelines and large studio outsourcing.",
       },
       {
-        title: "Web & Content Production",
+        title: "Web Production and Content Systems",
         description:
-          "Modern web platforms and content systems optimized for clarity and reach.",
-        bullets: [
-          "Corporate sites",
-          "Landing pages",
-          "Multilingual blogs (like NeoWhisper Blog)",
-        ],
+          "Corporate sites, landing pages, and multilingual content platforms.",
+        includes: "Includes: UX structure, implementation, CMS/blog workflow setup.",
+        excludes: "Not included by default: high-volume ad media operations.",
       },
       {
         title: "Translation & Localization (EN/AR/JP)",
         description:
-          "Seamless adaptation of software, apps, websites, and content for global audiences with technical accuracy.",
-        bullets: [
-          "App UI strings",
-          "Technical documentation",
-          "Marketing pages",
-        ],
+          "Technical translation and software localization for English, Arabic, and Japanese.",
+        includes: "Includes: UI strings, documentation, and product content localization.",
+        excludes: "Not included by default: legal-certified translation services.",
       },
     ],
-    cta: "Tell me about your project",
+    inProgress: [
+      "Client dashboard templates for workflow and analytics are being refined.",
+    ],
+    planned: [
+      "Reusable localization kits for recurring EN/JA/AR launch workflows.",
+    ],
+    cta: "Start a Project",
   },
   ja: {
     label: "サービス",
-    title: "提供できること",
-    subtitle: "開業届の事業概要に沿ったITサービスを提供します。",
+    title: "現在提供中のサービス",
+    subtitle: "今日ご相談いただける提供範囲です。",
     back: "ホームへ戻る",
-    cards: [
+    nowTitle: "現在提供中",
+    inProgressTitle: "進行中",
+    plannedTitle: "計画",
+    flowTitle: "提供フロー",
+    flow: "ヒアリング -> 要件定義 -> 開発 -> 引き渡し",
+    nowCards: [
       {
-        title: "ソフトウェア・ツール開発",
-        description: "業務効率を改善するカスタムソフトウェアや自動化ツール、API連携システムを構築します。",
-        bullets: ["社内ダッシュボード", "業務自動化ツール", "各種API連携"],
+        title: "ソフトウェア・Webアプリ開発",
+        description: "業務システム、社内ツール、Webアプリを要件に合わせて実装します。",
+        includes: "含まれるもの: 要件整理、実装、テスト、公開支援。",
+        excludes: "標準では含まれないもの: 24時間運用保守、監査対応。",
       },
       {
         title: "ゲーム開発",
-        description: "エンゲージメントを高めるインタラクティブな体験や、高品質なゲームプロトタイプを制作します。",
-        bullets: ["カジュアルゲーム試作", "インディーゲームMVP", "垂直スライス版制作"],
+        description: "スマホ向けカジュアルゲーム試作や小規模インディー開発に対応します。",
+        includes: "含まれるもの: プロトタイプ制作、改善反映、ビルド提供。",
+        excludes: "標準では含まれないもの: 大規模ライブ運用体制の代行。",
       },
       {
         title: "Web・コンテンツ制作",
-        description: "情報の伝わりやすさとリーチを追求した、モダンなWebプラットフォームとコンテンツ基盤を提供します。",
-        bullets: ["コーポレートサイト", "ランディングページ", "多言語ブログ（NeoWhisper Blogなど）"],
+        description: "企業サイト、LP、多言語コンテンツ基盤を設計・実装します。",
+        includes: "含まれるもの: 情報設計、実装、CMS/ブログ運用構成。",
+        excludes: "標準では含まれないもの: 大量広告メディア運用。",
       },
       {
         title: "翻訳・ローカライズ (日本語/英語/アラビア語)",
-        description: "グローバルに展開する製品やコンテンツを、技術的正確さを保ちつつ多言語へ最適化します。",
-        bullets: ["アプリUI文言", "技術ドキュメント", "マーケティングページ"],
+        description: "英語・アラビア語・日本語の技術翻訳とプロダクト向けローカライズを提供します。",
+        includes: "含まれるもの: UI文言、技術文書、製品コンテンツ。",
+        excludes: "標準では含まれないもの: 法的証明付き翻訳。",
       },
     ],
-    cta: "プロジェクトについて相談する",
+    inProgress: [
+      "業務分析と可視化向けダッシュボード雛形を現在整備中です。",
+    ],
+    planned: [
+      "EN/JA/ARの反復案件向けローカライズキットを計画中です。",
+    ],
+    cta: "プロジェクト相談を始める",
   },
   ar: {
     label: "الخدمات",
-    title: "خدماتنا",
-    subtitle: "نقدم نطاق خدمات تقنية المعلومات وفقًا لوصف النشاط المسجل.",
+    title: "الخدمات المتاحة الآن",
+    subtitle: "هذا هو نطاق الخدمات الذي يمكن طلبه اليوم.",
     back: "العودة للرئيسية",
-    cards: [
+    nowTitle: "متاح الآن",
+    inProgressTitle: "قيد التنفيذ",
+    plannedTitle: "مخطط",
+    flowTitle: "آلية التنفيذ",
+    flow: "اكتشاف -> تحديد نطاق -> بناء -> تسليم",
+    nowCards: [
       {
-        title: "تطوير البرمجيات والأدوات",
-        description: "حلول برمجية مخصصة، أدوات أتمتة، وأنظمة متكاملة لعمليات الأعمال.",
-        bullets: ["لوحات تحكم داخلية", "أدوات الأتمتة", "ربط واجهات API"],
+        title: "تطوير البرمجيات وتطبيقات الويب",
+        description: "نطوّر أنظمة أعمال وأدوات داخلية وتطبيقات ويب حسب متطلبات التشغيل.",
+        includes: "يشمل: تحديد النطاق، التنفيذ، الاختبار، ودعم الإطلاق.",
+        excludes: "لا يشمل افتراضياً: تشغيل 24/7 أو تدقيقات امتثال مؤسسية.",
       },
       {
         title: "تطوير الألعاب",
-        description: "تجارب تفاعلية ونماذج ألعاب أولية مبنية بجودة وإتقان.",
-        bullets: ["نماذج ألعاب موبايل", "نسخ MVP للألعاب", "تطوير أنظمة اللعب"],
+        description: "نماذج أولية للألعاب المحمولة وتطوير ألعاب مستقلة صغيرة.",
+        includes: "يشمل: نموذج لعب أولي، جولات تحسين، وتسليم نسخ البناء.",
+        excludes: "لا يشمل افتراضياً: إدارة تشغيل مباشر واسعة النطاق.",
       },
       {
-        title: "إنتاج الويب والمحتوى",
-        description: "منصات ويب حديثة وأنظمة محتوى محسنة للوضوح والوصول.",
-        bullets: ["مواقع شركات", "صفحات هبوط (Landing Pages)", "مدونات متعددة اللغات"],
+        title: "إنتاج الويب وأنظمة المحتوى",
+        description: "تنفيذ مواقع الشركات وصفحات الهبوط ومنصات محتوى متعددة اللغات.",
+        includes: "يشمل: هيكلة المحتوى، التنفيذ، وإعداد سير تشغيل المنصة.",
+        excludes: "لا يشمل افتراضياً: تشغيل إعلام إعلاني عالي الحجم.",
       },
       {
         title: "الترجمة والتعريب (EN/AR/JP)",
-        description: "تكييف المنتجات والمحتوى للجمهور العالمي بدقة تقنية عالية.",
-        bullets: ["نصوص الواجهات", "الوثائق التقنية", "صفحات التسويق"],
+        description: "ترجمة تقنية وتعريب برمجي بين الإنجليزية والعربية واليابانية.",
+        includes: "يشمل: نصوص الواجهة، الوثائق التقنية، ومحتوى المنتج.",
+        excludes: "لا يشمل افتراضياً: الترجمة القانونية الموثقة.",
       },
     ],
-    cta: "أخبرني عن مشروعك",
+    inProgress: [
+      "نعمل حالياً على قوالب لوحات تشغيلية لمتابعة المهام والتحليلات.",
+    ],
+    planned: [
+      "إعداد حزم تعريب قابلة لإعادة الاستخدام لمشاريع EN/JA/AR المتكررة.",
+    ],
+    cta: "ابدأ طلب مشروع",
   },
 } as const;
 
@@ -220,8 +248,15 @@ export default async function ServicesPage({
           </Link>
         </div>
 
-        <div className="grid gap-6 md:grid-cols-2">
-          {t.cards.map((service) => (
+        <section className="mb-8 rounded-3xl border border-white/20 bg-purple-600/5 p-6 dark:border-white/10">
+          <h2 className="text-xl font-bold text-gray-900 dark:text-white">{t.flowTitle}</h2>
+          <p className="mt-2 text-sm text-gray-700 dark:text-gray-300">{t.flow}</p>
+        </section>
+
+        <section className="mb-10">
+          <h2 className="mb-4 text-2xl font-bold text-gray-900 dark:text-white">{t.nowTitle}</h2>
+          <div className="grid gap-6 md:grid-cols-2">
+            {t.nowCards.map((service) => (
             <article
               key={service.title}
               className="rounded-3xl border border-white/20 bg-white/60 p-6 shadow-lg backdrop-blur-lg dark:border-white/10 dark:bg-white/5"
@@ -232,19 +267,37 @@ export default async function ServicesPage({
               <p className="mt-3 text-sm text-gray-600 dark:text-gray-300">
                 {service.description}
               </p>
-              <div className="mt-4 flex flex-wrap gap-2">
-                {service.bullets.map((bullet) => (
-                  <span
-                    key={bullet}
-                    className="rounded-full border border-white/30 bg-white/70 px-3 py-1 text-xs font-semibold text-gray-700 dark:border-white/10 dark:bg-white/10 dark:text-gray-200"
-                  >
-                    {bullet}
-                  </span>
-                ))}
+              <div className="mt-4 space-y-2 text-xs">
+                <p className="rounded-xl border border-white/20 bg-white/70 px-3 py-2 text-gray-700 dark:border-white/10 dark:bg-white/10 dark:text-gray-200">
+                  {service.includes}
+                </p>
+                <p className="rounded-xl border border-white/20 bg-white/70 px-3 py-2 text-gray-600 dark:border-white/10 dark:bg-white/5 dark:text-gray-300">
+                  {service.excludes}
+                </p>
               </div>
             </article>
-          ))}
-        </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="mb-10 grid gap-6 md:grid-cols-2">
+          <article className="rounded-3xl border border-white/20 bg-white/50 p-6 dark:border-white/10 dark:bg-white/5">
+            <h2 className="text-xl font-bold text-gray-900 dark:text-white">{t.inProgressTitle}</h2>
+            <ul className="mt-3 list-disc space-y-2 pl-5 text-sm text-gray-700 dark:text-gray-300">
+              {t.inProgress.map((item) => (
+                <li key={item}>{item}</li>
+              ))}
+            </ul>
+          </article>
+          <article className="rounded-3xl border border-white/20 bg-white/50 p-6 dark:border-white/10 dark:bg-white/5">
+            <h2 className="text-xl font-bold text-gray-900 dark:text-white">{t.plannedTitle}</h2>
+            <ul className="mt-3 list-disc space-y-2 pl-5 text-sm text-gray-700 dark:text-gray-300">
+              {t.planned.map((item) => (
+                <li key={item}>{item}</li>
+              ))}
+            </ul>
+          </article>
+        </section>
 
         <div className="mt-16 flex justify-center">
           <Link

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -1,19 +1,27 @@
 import type { SupportedLang } from "@/lib/i18n";
 
-export type ProjectStatus = "live" | "planned";
+export type ContentState = "now" | "in_progress" | "planned";
 
 export interface ProjectLink {
   label: string;
   href?: string;
 }
 
+export interface ProjectProof {
+  challenge: string;
+  scope: string;
+  stack: string;
+  outcome: string;
+}
+
 export interface ProjectCard {
   title: string;
   description: string;
   tags: string[];
-  status: ProjectStatus;
+  status: ContentState;
   image: string;
   links: ProjectLink[];
+  proof?: ProjectProof;
 }
 
 const projectsByLang: Record<SupportedLang, ProjectCard[]> = {
@@ -23,36 +31,72 @@ const projectsByLang: Record<SupportedLang, ProjectCard[]> = {
       description:
         "Multilingual blog platform (JP/EN/AR) built with Next.js and MDX; optimized for SEO and content publishing.",
       tags: ["Next.js", "MDX", "Tailwind", "i18n", "SEO"],
-      status: "live",
+      status: "now",
       image: "/images/nextjs-16-blog-tutorial.png",
       links: [
         { label: "View Live Site", href: "https://www.neowhisper.net" },
         { label: "View Code", href: "https://github.com/NeoWhisper/neowhisper-blog" },
       ],
+      proof: {
+        challenge: "Operate one codebase across JP/EN/AR content and routing.",
+        scope: "Implemented App Router i18n, metadata, and publishing workflow.",
+        stack: "Next.js, TypeScript, MDX, Tailwind, Supabase.",
+        outcome: "Shipped multilingual publishing in production with a maintainable workflow.",
+      },
     },
     {
       title: "Production Contact Pipeline",
       description:
         "End-to-end inquiry flow with anti-spam protection, transactional email delivery, and operational safety checks.",
       tags: ["Turnstile", "Resend", "Supabase", "Next.js API"],
-      status: "live",
+      status: "now",
       image: "/images/contact-form-cover.png",
       links: [
         { label: "View Contact Page", href: "/contact" },
         { label: "Read Implementation", href: "/blog/production-contact-forms-turnstile-resend" },
       ],
+      proof: {
+        challenge: "Filter spam while keeping inquiry submission simple.",
+        scope: "Built contact endpoint, validation, anti-bot checks, and mail flow.",
+        stack: "Next.js API routes, Turnstile, Resend, Supabase.",
+        outcome: "Deployed a stable inquiry pipeline suitable for real client intake.",
+      },
     },
     {
       title: "Security Hardening Rollout",
       description:
         "Nonce-based CSP, targeted CORS controls, and iterative policy tuning for AdSense + analytics compatibility on Vercel.",
       tags: ["CSP", "CORS", "Vercel", "Security"],
-      status: "live",
+      status: "now",
       image: "/images/csp-debugging-cover.png",
       links: [
         { label: "Read CSP Case Study", href: "/blog/debugging-csp-errors-adsense" },
         { label: "View Editorial Policy", href: "/editorial-policy" },
       ],
+      proof: {
+        challenge: "Allow required third-party scripts without weakening baseline security.",
+        scope: "Implemented nonce-based CSP and iterative allowlist controls.",
+        stack: "Next.js middleware/proxy, Vercel, security headers.",
+        outcome: "Hardened policy configuration now used by the production site.",
+      },
+    },
+    {
+      title: "Client Dashboards (Roadmap)",
+      description:
+        "Operational dashboard templates for internal analytics and workflow tracking.",
+      tags: ["Roadmap", "Dashboard", "Internal Tools"],
+      status: "in_progress",
+      image: "/images/nextjs-16-blog-tutorial.png",
+      links: [{ label: "Roadmap Item" }],
+    },
+    {
+      title: "Localization Kits (Planned)",
+      description:
+        "Reusable localization workflow assets for EN/JA/AR launch support.",
+      tags: ["Planned", "Localization", "Workflow"],
+      status: "planned",
+      image: "/images/nextjs-16-blog-tutorial.png",
+      links: [{ label: "Planned" }],
     },
   ],
   ja: [
@@ -61,36 +105,72 @@ const projectsByLang: Record<SupportedLang, ProjectCard[]> = {
       description:
         "Next.jsとMDXで構築された多言語ブログ（日本語/英語/アラビア語）。SEOとコンテンツ配信に最適化されています。",
       tags: ["Next.js", "MDX", "Tailwind", "i18n", "SEO"],
-      status: "live",
+      status: "now",
       image: "/images/nextjs-16-blog-tutorial.png",
       links: [
         { label: "ライブサイトを見る", href: "https://www.neowhisper.net" },
         { label: "コードを見る", href: "https://github.com/NeoWhisper/neowhisper-blog" },
       ],
+      proof: {
+        challenge: "1つのコードベースで日英アラビア語運用を実現すること。",
+        scope: "App Router多言語設計・メタデータ・配信フローを実装。",
+        stack: "Next.js、TypeScript、MDX、Tailwind、Supabase。",
+        outcome: "多言語運用を本番で回せる公開基盤を構築。",
+      },
     },
     {
       title: "本番向けお問い合わせ基盤",
       description:
         "スパム対策、メール送信、運用上の安全性を組み込んだ、実運用対応のお問い合わせ導線。",
       tags: ["Turnstile", "Resend", "Supabase", "Next.js API"],
-      status: "live",
+      status: "now",
       image: "/images/contact-form-cover.png",
       links: [
         { label: "お問い合わせページ", href: "/contact" },
         { label: "実装記事を読む", href: "/blog/production-contact-forms-turnstile-resend-ja" },
       ],
+      proof: {
+        challenge: "スパムを抑えつつ離脱を増やさない導線設計。",
+        scope: "入力検証・Bot対策・通知送信までを一体実装。",
+        stack: "Next.js API、Turnstile、Resend、Supabase。",
+        outcome: "案件相談に使える問い合わせ導線を本番運用。",
+      },
     },
     {
       title: "セキュリティ強化ロールアウト",
       description:
         "Vercel環境で、AdSense/分析基盤との互換性を維持しつつ、nonceベースCSPとCORS制御を段階的に導入。",
       tags: ["CSP", "CORS", "Vercel", "Security"],
-      status: "live",
+      status: "now",
       image: "/images/csp-debugging-cover.png",
       links: [
         { label: "CSPケーススタディ", href: "/blog/debugging-csp-errors-adsense-ja" },
         { label: "編集ポリシーを見る", href: "/editorial-policy" },
       ],
+      proof: {
+        challenge: "必要な外部連携を許可しつつセキュリティ基準を維持すること。",
+        scope: "nonceベースCSPと許可ドメインを段階調整。",
+        stack: "Next.js middleware/proxy、Vercel、セキュリティヘッダー。",
+        outcome: "本番サイトで運用可能な強化ポリシーへ移行。",
+      },
+    },
+    {
+      title: "クライアントダッシュボード（進行中）",
+      description:
+        "運用分析やタスク可視化を目的とした社内向けダッシュボード構成を検証中。",
+      tags: ["進行中", "ダッシュボード", "業務ツール"],
+      status: "in_progress",
+      image: "/images/nextjs-16-blog-tutorial.png",
+      links: [{ label: "ロードマップ項目" }],
+    },
+    {
+      title: "ローカライズキット（計画）",
+      description:
+        "EN/JA/AR展開向けの翻訳運用テンプレートを整備予定。",
+      tags: ["計画", "ローカライズ", "ワークフロー"],
+      status: "planned",
+      image: "/images/nextjs-16-blog-tutorial.png",
+      links: [{ label: "計画中" }],
     },
   ],
   ar: [
@@ -99,36 +179,72 @@ const projectsByLang: Record<SupportedLang, ProjectCard[]> = {
       description:
         "منصة تدوين متعددة اللغات (اليابانية/الإنجليزية/العربية) مبنية بـ Next.js وMDX؛ محسنة لمحركات البحث والنشر.",
       tags: ["Next.js", "MDX", "Tailwind", "i18n", "SEO"],
-      status: "live",
+      status: "now",
       image: "/images/nextjs-16-blog-tutorial.png",
       links: [
         { label: "عرض الموقع", href: "https://www.neowhisper.net" },
         { label: "عرض الكود", href: "https://github.com/NeoWhisper/neowhisper-blog" },
       ],
+      proof: {
+        challenge: "تشغيل موقع واحد بثلاث لغات بشكل ثابت.",
+        scope: "تنفيذ بنية تعدد اللغات والميتا ومسار النشر.",
+        stack: "Next.js وTypeScript وMDX وTailwind وSupabase.",
+        outcome: "إطلاق منصة نشر متعددة اللغات تعمل في الإنتاج.",
+      },
     },
     {
       title: "مسار تواصل جاهز للإنتاج",
       description:
         "مسار متكامل لطلبات العملاء مع حماية من الرسائل المزعجة، إرسال بريد موثوق، وضوابط تشغيلية واضحة.",
       tags: ["Turnstile", "Resend", "Supabase", "Next.js API"],
-      status: "live",
+      status: "now",
       image: "/images/contact-form-cover.png",
       links: [
         { label: "صفحة التواصل", href: "/contact" },
         { label: "قراءة التنفيذ", href: "/blog/production-contact-forms-turnstile-resend-ar" },
       ],
+      proof: {
+        challenge: "تقليل الرسائل المزعجة بدون تعقيد تجربة التواصل.",
+        scope: "تنفيذ التحقق والحماية من البوتات ومسار الإشعارات.",
+        stack: "Next.js API وTurnstile وResend وSupabase.",
+        outcome: "تشغيل مسار تواصل موثوق مناسب لاستقبال طلبات العملاء.",
+      },
     },
     {
       title: "تنفيذ تقوية الأمان",
       description:
         "تطبيق CSP بالـ nonce وضبط CORS بشكل دقيق مع الحفاظ على توافق AdSense والتحليلات على Vercel.",
       tags: ["CSP", "CORS", "Vercel", "Security"],
-      status: "live",
+      status: "now",
       image: "/images/csp-debugging-cover.png",
       links: [
         { label: "دراسة حالة CSP", href: "/blog/debugging-csp-errors-adsense-ar" },
         { label: "سياسة التحرير", href: "/editorial-policy" },
       ],
+      proof: {
+        challenge: "السماح بالتكاملات الضرورية مع الحفاظ على سياسة أمان صارمة.",
+        scope: "تطبيق CSP بالـ nonce وضبط قوائم السماح تدريجياً.",
+        stack: "Next.js middleware/proxy وVercel وترويسات الأمان.",
+        outcome: "نشر إعدادات أمان محسنة قابلة للتشغيل في البيئة الحية.",
+      },
+    },
+    {
+      title: "لوحات تحكم العملاء (قيد التنفيذ)",
+      description:
+        "العمل على قوالب لوحات تشغيلية لمتابعة المهام والتحليلات الداخلية.",
+      tags: ["قيد التنفيذ", "لوحات تحكم", "أدوات داخلية"],
+      status: "in_progress",
+      image: "/images/nextjs-16-blog-tutorial.png",
+      links: [{ label: "عنصر خارطة الطريق" }],
+    },
+    {
+      title: "حزم التعريب (مخطط)",
+      description:
+        "إعداد أصول سير عمل قابلة لإعادة الاستخدام للإطلاقات EN/JA/AR.",
+      tags: ["مخطط", "تعريب", "سير عمل"],
+      status: "planned",
+      image: "/images/nextjs-16-blog-tutorial.png",
+      links: [{ label: "مخطط" }],
     },
   ],
 };


### PR DESCRIPTION
## Description

Repositions the public site around a truth-first service identity: NEO WHISPER as a Tokyo-based multilingual IT services business first, and content publishing second.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📝 Documentation update
- [x] 🎨 Style/UI changes
- [ ] ♻️ Refactor (no functional changes)
- [ ] ⚡ Performance improvement

## Implementation Summary

- Homepage realignment: clearer service-first value proposition, primary CTA to contact intake, secondary CTA to proof-of-work, and a dedicated `Now` service strip.
- Services truth model: explicit `Now Delivering`, `In Progress`, and `Planned` sections with scope boundaries (`includes` / `not included`) and realistic delivery flow.
- About authority upgrade: added professional founder/business identity block and operating principles with bounded personal exposure.
- Projects restructuring: shipped work shown first with concise proof blocks (challenge, scope, stack, outcome); non-shipped work separated into a labeled roadmap.
- Content contract/data model: introduced `status: now | in_progress | planned` for project/service representation.
- Editorial consistency: added site-wide copy policy doc for truth-first claims and prohibited exaggeration patterns.

## Acceptance Criteria Mapping

- [x] No homepage/services/project copy implies shipped capability when status is not `now`.
- [x] All future items are visually and textually labeled as `In Progress` or `Planned`.
- [x] Every key page (`/`, `/services`, `/about`, `/projects`) contains a visible primary contact/project CTA.
- [x] Contact path remains <= 2 clicks from homepage hero CTA.
- [x] EN/JA/AR claim strength and intent aligned in updated sections.
- [x] Legal/business identity appears in About/trust sections.

## Verification

- [x] `npm run lint`
- [x] `npm run build`

## Files Changed

- `src/app/(site)/page.tsx`
- `src/app/(site)/services/page.tsx`
- `src/app/(site)/about/page.tsx`
- `src/app/(site)/projects/page.tsx`
- `src/data/projects.ts`
- `docs/truth-first-copy-policy.md`

## Notes

No fabricated KPIs, customer logos, or unsupported performance claims were introduced.
